### PR TITLE
Add 2x RTX PRO 6000 (sm_120) SGLang TP-2 recipes: Inkling-Small-NVFP4 + DeepSeek-V4-Flash-0731

### DIFF
--- a/local-ai/model-instances/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2.json
+++ b/local-ai/model-instances/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2.json
@@ -1,0 +1,201 @@
+{
+  "id": "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2",
+  "model_slug": "deepseek-v4-flash-0731",
+  "hardware_slug": "rtx-pro-6000-blackwell-96gb",
+  "hardware_config": {
+    "count": 2,
+    "interconnect": "PCIe 5.0, x8 + x4 as reported by nvidia-smi under load (AM5 consumer lane split); host-mediated multi-GPU, no NVLink; NCCL_P2P_DISABLE=1 required on this board",
+    "power_limit_w_each": 300,
+    "note": "Max-Q Workstation Edition (300 W) variant of rtx-pro-6000-blackwell-96gb"
+  },
+  "weights": {
+    "slug": "fp8-fp4",
+    "format": "safetensors (vendor: fp8 e4m3 dense + fp4 experts, served as shipped)",
+    "precision": "FP8+FP4",
+    "repo": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062",
+    "size_gb": 156
+  },
+  "engine": {
+    "name": "sglang",
+    "version": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7 (stock; SGLang commit b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19); no patches",
+    "graph_mode": "full decode capture bs<=4; piecewise CUDA graph disabled"
+  },
+  "serving": {
+    "api": "openai/v1",
+    "tensor_parallel": 2,
+    "configured_max_context_tokens": 131072,
+    "measured_max_context_tokens": 131072,
+    "configured_max_running_sequences": 4,
+    "measured_max_request_concurrency": 4,
+    "measured_kv_cache_tokens": 1722368,
+    "kv_cache_dtype": "fp8_e4m3 (auto)",
+    "measured_context_note": "a request that produced a 128,000-token completion (finish=length) was served at the configured 131,072 context, i.e. the full window is usable; requests exceeding it return HTTP 400"
+  },
+  "runtime": {
+    "kind": "docker",
+    "launchable_by_cli": false,
+    "image": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7",
+    "accelerator_backend": "nvidia",
+    "container_port": 8011,
+    "host_port": 8011,
+    "ipc": "host",
+    "shm_size": "32g",
+    "environment": {
+      "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+      "CUDA_VISIBLE_DEVICES": "0,1",
+      "NVIDIA_VISIBLE_DEVICES": "${GPUS}",
+      "HF_HOME": "/data/huggingface",
+      "HF_HUB_OFFLINE": "1",
+      "NCCL_P2P_DISABLE": "1",
+      "NCCL_IB_DISABLE": "1",
+      "NCCL_P2P_LEVEL": "SYS",
+      "NCCL_PROTO": "LL,LL128,Simple",
+      "TORCH_CUDA_ARCH_LIST": "12.0a",
+      "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
+    },
+    "mounts": [
+      {
+        "source": "${HF_HOME}",
+        "target": "/data/huggingface",
+        "read_only": true
+      },
+      {
+        "source": "dsv4-sgl-cache (named volume)",
+        "target": "/root/.cache",
+        "read_only": false
+      }
+    ],
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--served-model-name",
+      "deepseek-v4-flash",
+      "--tp-size=2",
+      "--mem-fraction-static=0.93",
+      "--context-length=131072",
+      "--max-running-requests=4",
+      "--chunked-prefill-size=8192",
+      "--attention-backend=triton",
+      "--reasoning-parser=deepseek-v4",
+      "--tool-call-parser=deepseekv4",
+      "--disable-piecewise-cuda-graph",
+      "--cuda-graph-max-bs=4",
+      "--disable-custom-all-reduce",
+      "--trust-remote-code",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8011"
+    ],
+    "resolved_at_runtime": {
+      "attention_backend": "dsv4 (model-forced; overrides --attention-backend triton)",
+      "moe_runner_backend": "flashinfer_mxfp4",
+      "kv_cache_dtype": "fp8_e4m3"
+    },
+    "launch_command": "deepseek-v4-flash-0731/run.sh (docker run, foreground)"
+  },
+  "capabilities": {
+    "chat": true,
+    "reasoning": true,
+    "tools": true,
+    "vision": false
+  },
+  "status": "candidate",
+  "profile": "tp2",
+  "description": "DeepSeek-V4-Flash-0731 (vendor fp8 dense + fp4 experts, served stock) on two RTX PRO 6000 Blackwell Max-Q (sm_120) via the upstream SGLang dspark image, TP-2, ctx 131,072, thinking mode. No patches. Weights 74.9 GB per rank; MLA KV pool 1,722,368 tokens. The one trap: SGLang's DeepSeek-V4 template defaults to CHAT mode (zero reasoning tokens) — send chat_template_kwargs {\"thinking\": true} per request to match the vendor API's posture; enable_thinking is ignored and reasoning_effort only adds a prompt prefix.",
+  "traces": [
+    {
+      "date": "2026-08-25",
+      "event": "startup_success_stock",
+      "detail": "Upstream dspark image serves the model with no patches: weights load 46 s, 74.92 GB/rank; health in ~2 min when kernels are cached, up to ~10 min on a cold first start."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "gotcha_parser_flags",
+      "detail": "First probe launched without --reasoning-parser/--tool-call-parser: tool calls could not parse. Relaunched with --reasoning-parser deepseek-v4 --tool-call-parser deepseekv4 (names from the in-image ReasoningParser.DetectorMap / ToolCallParserEnum); positive control then PASS incl. parsed tool call."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "gotcha_chat_mode_default",
+      "detail": "SGLang dsv4 defaults to chat mode: 0 reasoning tokens unless chat_template_kwargs {\"thinking\": true} is sent per request (enable_thinking is ignored; reasoning_effort only adds a prompt prefix). Vendor API serves in thinking mode, so parity needs the kwarg."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "canary_parity",
+      "detail": "21-prompt parity check against the vendor API with thinking:true: 21/21 locally = 21/21 on the vendor API."
+    },
+    {
+      "date": "2026-08-26T12:54-05:00",
+      "event": "context_raise",
+      "detail": "ctx 65536 -> 131072 (mem-fraction-static 0.93): max_total_num_tokens=1,722,368, available_gpu_mem 6.0 GB after pools. Long-generation probes (primes to 4000, 600-digit binary, 40x40 table, 800 squares at a 32k budget) all 0 errors; a 12k budget was exhausted inside reasoning on the enumeration task (budget, not drift)."
+    },
+    {
+      "date": "2026-08-26T12:56-05:00",
+      "event": "benchmark",
+      "detail": "Idle-server tok/s bench (thinking:true): 56-58 tok/s effective on every prompt class, decode 57.8, TTFT 0.08 s; 4 concurrent 155.2 tok/s aggregate (46.5-48.2/stream, TTFT 0.35-0.42 s). Flat across output length."
+    },
+    {
+      "date": "2026-08-26",
+      "event": "thermal",
+      "detail": "Sustained load window 2026-08-26 (17 h, GPUs >= 50 % busy for 16.7 h, longest contiguous span 9.6 h): GPU peaks 88 C / 277-283 W (300 W limit), CPU package 85 C, VRM 57 C, NVMe 59 C; no throttling."
+    }
+  ],
+  "source": {
+    "repository": "https://github.com/ppickle1989/sm120-sglang-recipes",
+    "paths": [
+      "deepseek-v4-flash-0731/run.sh",
+      "manifest.json",
+      "benchmarks/deepseek-v4-flash-0731-tp2-tps-20260826.json"
+    ],
+    "commit": "769f4704362af24e355f4117b60dd6f544ea0580"
+  },
+  "benchmarks": {
+    "date": "2026-08-26",
+    "methodology": "OpenAI /v1/chat/completions, streaming (SSE) with usage in the final chunk; temperature 0.7 / top_p 0.8; four prompt classes x 2 runs (short 400 cap, reasoning, analytical, long 2500 cap); effective tok/s = completion_tokens (reasoning + content, from usage) / wall incl. TTFT; TTFT = first streamed delta of content or reasoning; decode tok/s excludes TTFT; 4-way concurrency on the reasoning prompt, aggregate = total completion tokens / batch wall. Idle server, GPUs at the 300 W Max-Q limit. Raw JSON + script in the source repo benchmarks/.",
+    "single_stream_effective_tok_s": {
+      "short": [
+        56.1,
+        56.2
+      ],
+      "reasoning": [
+        57.6,
+        57.6
+      ],
+      "analytical": [
+        57.7,
+        57.7
+      ],
+      "long_2500cap": [
+        57.7,
+        57.7
+      ],
+      "decode_tok_s": "57.7-57.9"
+    },
+    "decode_concurrency": [
+      {
+        "conc": 1,
+        "aggregate_tok_s": 57.7,
+        "per_stream_tok_s": [
+          57.7
+        ],
+        "ttft_s": 0.08
+      },
+      {
+        "conc": 4,
+        "aggregate_tok_s": 155.2,
+        "per_stream_tok_s": [
+          46.5,
+          48.2,
+          47.6,
+          46.6
+        ],
+        "ttft_s": 0.35
+      }
+    ],
+    "ttft_s_single": 0.08
+  }
+}

--- a/local-ai/model-instances/inkling-small-nvfp4-rtxpro6000-sglang-tp2.json
+++ b/local-ai/model-instances/inkling-small-nvfp4-rtxpro6000-sglang-tp2.json
@@ -1,0 +1,213 @@
+{
+  "id": "inkling-small-nvfp4-rtxpro6000-sglang-tp2",
+  "model_slug": "inkling-small",
+  "hardware_slug": "rtx-pro-6000-blackwell-96gb",
+  "hardware_config": {
+    "count": 2,
+    "interconnect": "PCIe 5.0, x8 + x4 as reported by nvidia-smi under load (AM5 consumer lane split); host-mediated multi-GPU, no NVLink; NCCL_P2P_DISABLE=1 required on this board",
+    "power_limit_w_each": 300,
+    "note": "Max-Q Workstation Edition (300 W) variant of rtx-pro-6000-blackwell-96gb"
+  },
+  "weights": {
+    "slug": "nvfp4",
+    "format": "ModelOpt",
+    "precision": "NVFP4",
+    "repo": "thinkingmachines/Inkling-Small-NVFP4",
+    "revision": "b6a99534467840620d411e4cd4ad5819b2610d9c",
+    "size_gb": 160
+  },
+  "engine": {
+    "name": "sglang",
+    "version": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7 + 1 patched file (SGLang commit b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19); built image local/sglang-inkling:sm120",
+    "graph_mode": "full decode capture bs<=4; piecewise CUDA graph disabled"
+  },
+  "serving": {
+    "api": "openai/v1",
+    "tensor_parallel": 2,
+    "configured_max_context_tokens": 131072,
+    "measured_max_context_tokens": null,
+    "configured_max_running_sequences": 4,
+    "measured_max_request_concurrency": 4,
+    "measured_kv_cache_tokens": 474388,
+    "kv_cache_dtype": "fp8_e5m2",
+    "measured_context_note": "a request that produced a 73,077-token completion (finish=stop) was served at the configured 131,072 context; requests exceeding it return HTTP 400"
+  },
+  "runtime": {
+    "kind": "docker",
+    "launchable_by_cli": false,
+    "image": "local/sglang-inkling:sm120 (build from source repo inkling-small-nvfp4/Dockerfile; base lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7)",
+    "accelerator_backend": "nvidia",
+    "container_port": 8010,
+    "host_port": 8010,
+    "ipc": "host",
+    "shm_size": "32g",
+    "environment": {
+      "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+      "CUDA_VISIBLE_DEVICES": "0,1",
+      "NVIDIA_VISIBLE_DEVICES": "${GPUS}",
+      "HF_HOME": "/data/huggingface",
+      "HF_HUB_OFFLINE": "1",
+      "NCCL_P2P_DISABLE": "1",
+      "NCCL_IB_DISABLE": "1",
+      "NCCL_P2P_LEVEL": "SYS",
+      "NCCL_PROTO": "LL,LL128,Simple",
+      "TORCH_CUDA_ARCH_LIST": "12.0a",
+      "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+      "SGLANG_INKLING_KEEP_PACKED_TOPK": "1"
+    },
+    "mounts": [
+      {
+        "source": "${HF_HOME}",
+        "target": "/data/huggingface",
+        "read_only": true
+      },
+      {
+        "source": "inkling-sgl-cache (named volume)",
+        "target": "/root/.cache",
+        "read_only": false
+      }
+    ],
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "thinkingmachines/Inkling-Small-NVFP4",
+      "--served-model-name",
+      "inkling-small",
+      "--tp-size=2",
+      "--mem-fraction-static=0.965",
+      "--context-length=131072",
+      "--max-running-requests=4",
+      "--chunked-prefill-size=8192",
+      "--attention-backend=triton",
+      "--moe-runner-backend=marlin",
+      "--kv-cache-dtype=fp8_e5m2",
+      "--reasoning-parser=inkling",
+      "--tool-call-parser=inkling",
+      "--disable-piecewise-cuda-graph",
+      "--cuda-graph-max-bs=4",
+      "--disable-custom-all-reduce",
+      "--trust-remote-code",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8010"
+    ],
+    "launch_command": "inkling-small-nvfp4/run.sh (docker run, foreground)"
+  },
+  "capabilities": {
+    "chat": true,
+    "reasoning": true,
+    "tools": true,
+    "vision": false
+  },
+  "status": "candidate",
+  "profile": "tp2",
+  "description": "Inkling-Small-NVFP4 on two RTX PRO 6000 Blackwell Max-Q (sm_120) via SGLang TP-2, ctx 131,072. Upstream dspark image + ONE patched kernel file (two one-line fixes: grouped-GEMM num_stages 4->3 for sm_120's 101,376 B shared memory; silu_and_mul rerouted from Helion, which has no sm_120 config, to the in-file Triton kernel — verified bit-exact). MoE runner marlin, attention triton, KV fp8_e5m2. Stock vLLM v0.27.1 has no sm_120 attention path for this model and asserts at startup; with a locally ported attention kernel it serves but computes garbage (cutlass NVFP4 MoE wrong at 256 experts/top-6 on sm_120; marlin-in-vLLM did not rescue that stack), so SGLang is the coherent path. Temporary bridge: retire when upstream SGLang ships sm_120 kernels for this model.",
+  "traces": [
+    {
+      "date": "2026-08-25T08:17-05:00",
+      "event": "vllm_first_light_garbage",
+      "detail": "Stock vLLM v0.27.1 asserts at startup (no sm_120 paged-KV attention for this model). With a locally ported sm_120 attention kernel it loads and serves; positive control FAILS: token salad in both reasoning and content at temp 1.0 / effort none. Marlin MoE swap inside vLLM (three variants) still garbage. Engine fault, not hardware/quant."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "nccl_init_hang",
+      "detail": "SGLang TP-2 NCCL init hung 26 min with both GPUs at 100% util (~1 GB) on this AM5 board; NCCL_P2P_DISABLE=1 -> init in 0.89 s."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "fix1_grouped_gemm_smem",
+      "detail": "'Required 110592 > 101376' from the small-M grouped-GEMM decode config; num_stages 4->3 (73,728 B) in inkling_moe.py."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "fix2_helion_silu",
+      "detail": "silu_and_mul_interleaved_sm_120.json missing and cannot be autogenerated (int32/int64 catch-22); interleaved branch rerouted to the in-file pure-Triton silu_and_mul_triton. Later tensor-level diff vs eager reference: bit-exact."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "startup_success",
+      "detail": "Health 200 in 215 s on first start (110 s on later starts with the kernel cache volume). Positive control PASS: factual Q&A, 17x23=391, tool call parses (inkling parser), thinking effort low/high/off all coherent; ~92-117 tok/s effective."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "canary_parity",
+      "detail": "21-prompt parity check against the vendor API: 21/21 locally = 21/21 on the vendor API for the same model (0 drop)."
+    },
+    {
+      "date": "2026-08-25T13:35-05:00",
+      "event": "managed_image_built",
+      "detail": "Bind-mount replaced by a built image: Dockerfile asserts the in-image original sha256 (f23a3775...) and the patched sha256 (c101a7e8...) at build time."
+    },
+    {
+      "date": "2026-08-25",
+      "event": "context_raise",
+      "detail": "ctx 32768 -> 65536 -> 131072; KV pool unchanged at 474,388 fp8_e5m2 tokens (fits 3 concurrent at 128k). bf16 KV pool would be 237,194 tokens; a 24/25 vs 25/25 retrieval probe showed no meaningful fp8-KV cost."
+    },
+    {
+      "date": "2026-08-26T02:14-05:00",
+      "event": "benchmark",
+      "detail": "Idle-server tok/s bench: ~115 tok/s effective on every prompt class, decode 114.6-117.9, TTFT 0.06 s; 4 concurrent 306.6 tok/s aggregate (~85/stream, TTFT 0.32 s). Later sustained load (9.6 h contiguous): peaks 88 C / 277-283 W per GPU, no throttling."
+    }
+  ],
+  "source": {
+    "repository": "https://github.com/ppickle1989/sm120-sglang-recipes",
+    "paths": [
+      "inkling-small-nvfp4/Dockerfile",
+      "inkling-small-nvfp4/patches/inkling_moe.py",
+      "inkling-small-nvfp4/patches/inkling_moe.diff",
+      "inkling-small-nvfp4/PROVENANCE.md",
+      "inkling-small-nvfp4/run.sh",
+      "manifest.json",
+      "benchmarks/inkling-small-nvfp4-tp2-tps-20260826.json"
+    ],
+    "commit": "769f4704362af24e355f4117b60dd6f544ea0580"
+  },
+  "benchmarks": {
+    "date": "2026-08-26",
+    "methodology": "OpenAI /v1/chat/completions, streaming (SSE) with usage in the final chunk; temperature 0.7 / top_p 0.8; four prompt classes x 2 runs (short 400 cap, reasoning, analytical, long 2500 cap); effective tok/s = completion_tokens (reasoning + content, from usage) / wall incl. TTFT; TTFT = first streamed delta of content or reasoning; decode tok/s excludes TTFT; 4-way concurrency on the reasoning prompt, aggregate = total completion tokens / batch wall. Idle server, GPUs at the 300 W Max-Q limit. Raw JSON + script in the source repo benchmarks/.",
+    "single_stream_effective_tok_s": {
+      "short": [
+        114.7,
+        114.7
+      ],
+      "reasoning": [
+        116.2,
+        115.0
+      ],
+      "analytical": [
+        115.2,
+        115.2
+      ],
+      "long_2500cap": [
+        115.5,
+        114.4
+      ],
+      "decode_tok_s": "114.6-117.9"
+    },
+    "decode_concurrency": [
+      {
+        "conc": 1,
+        "aggregate_tok_s": 115.0,
+        "per_stream_tok_s": [
+          115.0
+        ],
+        "ttft_s": 0.06
+      },
+      {
+        "conc": 4,
+        "aggregate_tok_s": 306.6,
+        "per_stream_tok_s": [
+          84.9,
+          83.7,
+          84.1,
+          84.1
+        ],
+        "ttft_s": 0.32
+      }
+    ],
+    "ttft_s_single": 0.06
+  }
+}

--- a/registry/index.json
+++ b/registry/index.json
@@ -585,6 +585,7 @@
       "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
       "deepseek-v4-flash-0731-exl3-3bpw-dgxspark-sparkinfer-tp1",
       "deepseek-v4-flash-0731-fp8-e4m3-rtx-3090-24gb-vllm-tp1",
+      "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2",
       "deepseek-v4-flash-0731-fp8-rtx-3090-24gb-vllm-tp1",
       "deepseek-v4-flash-0731-fp8-rtxpro6000-vllm-tp4",
       "deepseek-v4-flash-0731-iq2-xxs-radeon-ai-pro-r9700-32gb-lucebox-tp1-7ibvc9zx",
@@ -662,6 +663,7 @@
       "huihui-qwen3-8-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1",
       "hy3-fp8-rtxpro6000-vllm-tp4",
       "inkling-small-nvfp4-dgxspark-vllm-tp2",
+      "inkling-small-nvfp4-rtxpro6000-sglang-tp2",
       "kimi-k2-5-int4-rtx-pro-6000-blackwell-96gb-sglang-tp8",
       "kimi-k2.6-nvfp4-rtxpro6000-sglang-tp4",
       "lfm2-5-8b-a1b-base-int4-apple-m5-pro-48gb-mlx-tp1",
@@ -1626,6 +1628,7 @@
       "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1-sweep",
       "deepseek-v4-flash-0731-exl3-3bpw-dgxspark-sparkinfer-tp1-sweep",
       "deepseek-v4-flash-0731-fp8-e4m3-rtx-3090-24gb-vllm-tp1-sweep",
+      "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2-sweep",
       "deepseek-v4-flash-0731-fp8-rtx-3090-24gb-vllm-tp1-sweep",
       "deepseek-v4-flash-0731-iq2-xxs-radeon-ai-pro-r9700-32gb-lucebox-tp1-7ibvc9zx-sweep",
       "deepseek-v4-flash-0731-nvfp4-dgxspark-vllm-tp2-sweep",
@@ -1698,6 +1701,7 @@
       "huihui-qwen3-8-27b-abliterated-mlx-8bit-apple-m3-ultra-96gb-mlx-tp1-sweep",
       "huihui-qwen3-8-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1-sweep",
       "inkling-small-nvfp4-dgxspark-vllm-tp2-sweep",
+      "inkling-small-nvfp4-rtxpro6000-sglang-tp2-sweep",
       "kimi-k2-5-int4-rtx-pro-6000-blackwell-96gb-sglang-tp8-sweep",
       "lfm2-5-8b-a1b-base-int4-apple-m5-pro-48gb-mlx-tp1-sweep",
       "lfm2-5-8b-a1b-iq4-xs-rx-7700-xt-12gb-vllm-tp1-sweep",
@@ -3214,8 +3218,8 @@
     "hardware": 100,
     "model": 103,
     "model_instance": 372,
-    "recipe": 1039,
-    "speed_sweeps": 1585
+    "recipe": 1041,
+    "speed_sweeps": 1587
   },
   "recipes": [
     {
@@ -3267,6 +3271,23 @@
       "launch_kind": "reference",
       "model_instance_id": "deepseek-ai-deepseek-v4-flash-0731--fp8-e4m3",
       "recipe_source": "localmaxxing",
+      "status": "candidate"
+    },
+    {
+      "capabilities": {
+        "chat": true,
+        "reasoning": true,
+        "tools": true,
+        "vision": false
+      },
+      "engine": "sglang",
+      "hardware_count": 2,
+      "hardware_id": "rtx-pro-6000-blackwell-96gb",
+      "has_evidence": true,
+      "id": "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2",
+      "launch_kind": "docker",
+      "model_instance_id": "deepseek-ai-deepseek-v4-flash-0731--fp8",
+      "recipe_source": "ppickle1989",
       "status": "candidate"
     },
     {
@@ -4576,6 +4597,23 @@
       "launch_kind": "docker-compose",
       "model_instance_id": "thinkingmachines-inkling-small-nvfp4--nvfp4",
       "recipe_source": "0xsero",
+      "status": "candidate"
+    },
+    {
+      "capabilities": {
+        "chat": true,
+        "reasoning": true,
+        "tools": true,
+        "vision": false
+      },
+      "engine": "sglang",
+      "hardware_count": 2,
+      "hardware_id": "rtx-pro-6000-blackwell-96gb",
+      "has_evidence": true,
+      "id": "inkling-small-nvfp4-rtxpro6000-sglang-tp2",
+      "launch_kind": "docker",
+      "model_instance_id": "thinkingmachines-inkling-small-nvfp4--nvfp4",
+      "recipe_source": "ppickle1989",
       "status": "candidate"
     },
     {

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2.json
@@ -1,0 +1,148 @@
+{
+  "capabilities": {
+    "chat": true,
+    "reasoning": true,
+    "tools": true,
+    "vision": false
+  },
+  "description": "DeepSeek-V4-Flash-0731 (vendor fp8 dense + fp4 experts, served stock) on two RTX PRO 6000 Blackwell Max-Q (sm_120) via the upstream SGLang dspark image, TP-2, ctx 131,072, thinking mode. No patches. Weights 74.9 GB per rank; MLA KV pool 1,722,368 tokens. The one trap: SGLang's DeepSeek-V4 template defaults to CHAT mode (zero reasoning tokens) \u2014 send chat_template_kwargs {\"thinking\": true} per request to match the vendor API's posture; enable_thinking is ignored and reasoning_effort only adds a prompt prefix.",
+  "engine": {
+    "graph_mode": "full decode capture bs<=4; piecewise CUDA graph disabled",
+    "name": "sglang",
+    "version": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7 (stock; SGLang commit b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19); no patches"
+  },
+  "hardware_count": 2,
+  "hardware_id": "rtx-pro-6000-blackwell-96gb",
+  "id": "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2",
+  "launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--served-model-name",
+      "deepseek-v4-flash",
+      "--tp-size=2",
+      "--mem-fraction-static=0.93",
+      "--context-length=131072",
+      "--max-running-requests=4",
+      "--chunked-prefill-size=8192",
+      "--attention-backend=triton",
+      "--reasoning-parser=deepseek-v4",
+      "--tool-call-parser=deepseekv4",
+      "--disable-piecewise-cuda-graph",
+      "--cuda-graph-max-bs=4",
+      "--disable-custom-all-reduce",
+      "--trust-remote-code",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8011"
+    ],
+    "container_port": 8011,
+    "environment": {
+      "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+      "CUDA_VISIBLE_DEVICES": "0,1",
+      "HF_HOME": "/data/huggingface",
+      "HF_HUB_OFFLINE": "1",
+      "NCCL_IB_DISABLE": "1",
+      "NCCL_P2P_DISABLE": "1",
+      "NCCL_P2P_LEVEL": "SYS",
+      "NCCL_PROTO": "LL,LL128,Simple",
+      "NVIDIA_VISIBLE_DEVICES": "${GPUS}",
+      "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+      "TORCH_CUDA_ARCH_LIST": "12.0a"
+    },
+    "host_port": 8011,
+    "image": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7",
+    "ipc": "host",
+    "kind": "docker",
+    "launch_command": "deepseek-v4-flash-0731/run.sh (docker run, foreground)",
+    "mounts": [
+      {
+        "read_only": true,
+        "source": "${HF_HOME}",
+        "target": "/data/huggingface"
+      },
+      {
+        "read_only": false,
+        "source": "dsv4-sgl-cache (named volume)",
+        "target": "/root/.cache"
+      }
+    ],
+    "shm_size": "32g",
+    "source": {
+      "commit": "769f4704362af24e355f4117b60dd6f544ea0580",
+      "paths": [
+        "deepseek-v4-flash-0731/run.sh",
+        "manifest.json",
+        "benchmarks/deepseek-v4-flash-0731-tp2-tps-20260826.json"
+      ],
+      "repository": "https://github.com/ppickle1989/sm120-sglang-recipes"
+    }
+  },
+  "metadata": {
+    "acceptance": {
+      "completion": true,
+      "tools": true,
+      "vision": false
+    },
+    "context_note": "a request that produced a 128,000-token completion (finish=length) was served at the configured 131,072 context, i.e. the full window is usable; requests exceeding it return HTTP 400",
+    "hardware_variant": "RTX PRO 6000 Blackwell Max-Q Workstation Edition (300 W)",
+    "interconnect": "PCIe 5.0, x8 + x4 as reported by nvidia-smi under load (AM5 consumer lane split); host-mediated multi-GPU, no NVLink; NCCL_P2P_DISABLE=1 required on this board",
+    "traces": [
+      {
+        "date": "2026-08-25",
+        "detail": "Upstream dspark image serves the model with no patches: weights load 46 s, 74.92 GB/rank; health in ~2 min when kernels are cached, up to ~10 min on a cold first start.",
+        "event": "startup_success_stock"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "First probe launched without --reasoning-parser/--tool-call-parser: tool calls could not parse. Relaunched with --reasoning-parser deepseek-v4 --tool-call-parser deepseekv4 (names from the in-image ReasoningParser.DetectorMap / ToolCallParserEnum); positive control then PASS incl. parsed tool call.",
+        "event": "gotcha_parser_flags"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "SGLang dsv4 defaults to chat mode: 0 reasoning tokens unless chat_template_kwargs {\"thinking\": true} is sent per request (enable_thinking is ignored; reasoning_effort only adds a prompt prefix). Vendor API serves in thinking mode, so parity needs the kwarg.",
+        "event": "gotcha_chat_mode_default"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "21-prompt parity check against the vendor API with thinking:true: 21/21 locally = 21/21 on the vendor API.",
+        "event": "canary_parity"
+      },
+      {
+        "date": "2026-08-26T12:54-05:00",
+        "detail": "ctx 65536 -> 131072 (mem-fraction-static 0.93): max_total_num_tokens=1,722,368, available_gpu_mem 6.0 GB after pools. Long-generation probes (primes to 4000, 600-digit binary, 40x40 table, 800 squares at a 32k budget) all 0 errors; a 12k budget was exhausted inside reasoning on the enumeration task (budget, not drift).",
+        "event": "context_raise"
+      },
+      {
+        "date": "2026-08-26T12:56-05:00",
+        "detail": "Idle-server tok/s bench (thinking:true): 56-58 tok/s effective on every prompt class, decode 57.8, TTFT 0.08 s; 4 concurrent 155.2 tok/s aggregate (46.5-48.2/stream, TTFT 0.35-0.42 s). Flat across output length.",
+        "event": "benchmark"
+      },
+      {
+        "date": "2026-08-26",
+        "detail": "Sustained load window 2026-08-26 (17 h, GPUs >= 50 % busy for 16.7 h, longest contiguous span 9.6 h): GPU peaks 88 C / 277-283 W (300 W limit), CPU package 85 C, VRM 57 C, NVMe 59 C; no throttling.",
+        "event": "thermal"
+      }
+    ]
+  },
+  "model_instance_id": "deepseek-ai-deepseek-v4-flash-0731--fp8",
+  "recipe_source": "ppickle1989",
+  "schema_version": "local-ai-registry/v1",
+  "serving": {
+    "api": "openai/v1",
+    "kv_cache_dtype": "fp8_e4m3 (auto)",
+    "kv_cache_tokens": 1722368,
+    "max_concurrency": 4,
+    "max_context_tokens": 131072,
+    "tensor_parallel": 2
+  },
+  "speed_sweeps_ids": [
+    "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2-sweep"
+  ],
+  "status": "candidate"
+}

--- a/registry/recipe/inkling-small-nvfp4-rtxpro6000-sglang-tp2.json
+++ b/registry/recipe/inkling-small-nvfp4-rtxpro6000-sglang-tp2.json
@@ -1,0 +1,165 @@
+{
+  "capabilities": {
+    "chat": true,
+    "reasoning": true,
+    "tools": true,
+    "vision": false
+  },
+  "description": "Inkling-Small-NVFP4 on two RTX PRO 6000 Blackwell Max-Q (sm_120) via SGLang TP-2, ctx 131,072. Upstream dspark image + ONE patched kernel file (two one-line fixes: grouped-GEMM num_stages 4->3 for sm_120's 101,376 B shared memory; silu_and_mul rerouted from Helion, which has no sm_120 config, to the in-file Triton kernel \u2014 verified bit-exact). MoE runner marlin, attention triton, KV fp8_e5m2. Stock vLLM v0.27.1 has no sm_120 attention path for this model and asserts at startup; with a locally ported attention kernel it serves but computes garbage (cutlass NVFP4 MoE wrong at 256 experts/top-6 on sm_120; marlin-in-vLLM did not rescue that stack), so SGLang is the coherent path. Temporary bridge: retire when upstream SGLang ships sm_120 kernels for this model.",
+  "engine": {
+    "graph_mode": "full decode capture bs<=4; piecewise CUDA graph disabled",
+    "name": "sglang",
+    "version": "lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7 + 1 patched file (SGLang commit b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19); built image local/sglang-inkling:sm120"
+  },
+  "hardware_count": 2,
+  "hardware_id": "rtx-pro-6000-blackwell-96gb",
+  "id": "inkling-small-nvfp4-rtxpro6000-sglang-tp2",
+  "launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "thinkingmachines/Inkling-Small-NVFP4",
+      "--served-model-name",
+      "inkling-small",
+      "--tp-size=2",
+      "--mem-fraction-static=0.965",
+      "--context-length=131072",
+      "--max-running-requests=4",
+      "--chunked-prefill-size=8192",
+      "--attention-backend=triton",
+      "--moe-runner-backend=marlin",
+      "--kv-cache-dtype=fp8_e5m2",
+      "--reasoning-parser=inkling",
+      "--tool-call-parser=inkling",
+      "--disable-piecewise-cuda-graph",
+      "--cuda-graph-max-bs=4",
+      "--disable-custom-all-reduce",
+      "--trust-remote-code",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8010"
+    ],
+    "container_port": 8010,
+    "environment": {
+      "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+      "CUDA_VISIBLE_DEVICES": "0,1",
+      "HF_HOME": "/data/huggingface",
+      "HF_HUB_OFFLINE": "1",
+      "NCCL_IB_DISABLE": "1",
+      "NCCL_P2P_DISABLE": "1",
+      "NCCL_P2P_LEVEL": "SYS",
+      "NCCL_PROTO": "LL,LL128,Simple",
+      "NVIDIA_VISIBLE_DEVICES": "${GPUS}",
+      "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+      "SGLANG_INKLING_KEEP_PACKED_TOPK": "1",
+      "TORCH_CUDA_ARCH_LIST": "12.0a"
+    },
+    "host_port": 8010,
+    "image": "local/sglang-inkling:sm120 (build from source repo inkling-small-nvfp4/Dockerfile; base lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e25b26660dbc2384a27ead8817e9b7670f257b5c3143e0450d14524d7)",
+    "ipc": "host",
+    "kind": "docker",
+    "launch_command": "inkling-small-nvfp4/run.sh (docker run, foreground)",
+    "mounts": [
+      {
+        "read_only": true,
+        "source": "${HF_HOME}",
+        "target": "/data/huggingface"
+      },
+      {
+        "read_only": false,
+        "source": "inkling-sgl-cache (named volume)",
+        "target": "/root/.cache"
+      }
+    ],
+    "shm_size": "32g",
+    "source": {
+      "commit": "769f4704362af24e355f4117b60dd6f544ea0580",
+      "paths": [
+        "inkling-small-nvfp4/Dockerfile",
+        "inkling-small-nvfp4/patches/inkling_moe.py",
+        "inkling-small-nvfp4/patches/inkling_moe.diff",
+        "inkling-small-nvfp4/PROVENANCE.md",
+        "inkling-small-nvfp4/run.sh",
+        "manifest.json",
+        "benchmarks/inkling-small-nvfp4-tp2-tps-20260826.json"
+      ],
+      "repository": "https://github.com/ppickle1989/sm120-sglang-recipes"
+    }
+  },
+  "metadata": {
+    "acceptance": {
+      "completion": true,
+      "tools": true,
+      "vision": false
+    },
+    "context_note": "a request that produced a 73,077-token completion (finish=stop) was served at the configured 131,072 context; requests exceeding it return HTTP 400",
+    "hardware_variant": "RTX PRO 6000 Blackwell Max-Q Workstation Edition (300 W)",
+    "interconnect": "PCIe 5.0, x8 + x4 as reported by nvidia-smi under load (AM5 consumer lane split); host-mediated multi-GPU, no NVLink; NCCL_P2P_DISABLE=1 required on this board",
+    "traces": [
+      {
+        "date": "2026-08-25T08:17-05:00",
+        "detail": "Stock vLLM v0.27.1 asserts at startup (no sm_120 paged-KV attention for this model). With a locally ported sm_120 attention kernel it loads and serves; positive control FAILS: token salad in both reasoning and content at temp 1.0 / effort none. Marlin MoE swap inside vLLM (three variants) still garbage. Engine fault, not hardware/quant.",
+        "event": "vllm_first_light_garbage"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "SGLang TP-2 NCCL init hung 26 min with both GPUs at 100% util (~1 GB) on this AM5 board; NCCL_P2P_DISABLE=1 -> init in 0.89 s.",
+        "event": "nccl_init_hang"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "'Required 110592 > 101376' from the small-M grouped-GEMM decode config; num_stages 4->3 (73,728 B) in inkling_moe.py.",
+        "event": "fix1_grouped_gemm_smem"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "silu_and_mul_interleaved_sm_120.json missing and cannot be autogenerated (int32/int64 catch-22); interleaved branch rerouted to the in-file pure-Triton silu_and_mul_triton. Later tensor-level diff vs eager reference: bit-exact.",
+        "event": "fix2_helion_silu"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "Health 200 in 215 s on first start (110 s on later starts with the kernel cache volume). Positive control PASS: factual Q&A, 17x23=391, tool call parses (inkling parser), thinking effort low/high/off all coherent; ~92-117 tok/s effective.",
+        "event": "startup_success"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "21-prompt parity check against the vendor API: 21/21 locally = 21/21 on the vendor API for the same model (0 drop).",
+        "event": "canary_parity"
+      },
+      {
+        "date": "2026-08-25T13:35-05:00",
+        "detail": "Bind-mount replaced by a built image: Dockerfile asserts the in-image original sha256 (f23a3775...) and the patched sha256 (c101a7e8...) at build time.",
+        "event": "managed_image_built"
+      },
+      {
+        "date": "2026-08-25",
+        "detail": "ctx 32768 -> 65536 -> 131072; KV pool unchanged at 474,388 fp8_e5m2 tokens (fits 3 concurrent at 128k). bf16 KV pool would be 237,194 tokens; a 24/25 vs 25/25 retrieval probe showed no meaningful fp8-KV cost.",
+        "event": "context_raise"
+      },
+      {
+        "date": "2026-08-26T02:14-05:00",
+        "detail": "Idle-server tok/s bench: ~115 tok/s effective on every prompt class, decode 114.6-117.9, TTFT 0.06 s; 4 concurrent 306.6 tok/s aggregate (~85/stream, TTFT 0.32 s). Later sustained load (9.6 h contiguous): peaks 88 C / 277-283 W per GPU, no throttling.",
+        "event": "benchmark"
+      }
+    ]
+  },
+  "model_instance_id": "thinkingmachines-inkling-small-nvfp4--nvfp4",
+  "recipe_source": "ppickle1989",
+  "schema_version": "local-ai-registry/v1",
+  "serving": {
+    "api": "openai/v1",
+    "kv_cache_dtype": "fp8_e5m2",
+    "kv_cache_tokens": 474388,
+    "max_concurrency": 4,
+    "max_context_tokens": 131072,
+    "tensor_parallel": 2
+  },
+  "speed_sweeps_ids": [
+    "inkling-small-nvfp4-rtxpro6000-sglang-tp2-sweep"
+  ],
+  "status": "candidate"
+}

--- a/registry/speed-sweeps/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2-sweep.json
+++ b/registry/speed-sweeps/deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2-sweep.json
@@ -1,0 +1,92 @@
+{
+  "accepted_at": null,
+  "id": "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2-sweep",
+  "measured_at": "2026-08-26",
+  "recipe_id": "deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2",
+  "rows": [
+    {
+      "concurrency": 1,
+      "context_tokens": 30,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 57.85,
+      "decode_tok_s_per_stream": 57.85,
+      "effective_tok_s_incl_ttft": 56.15,
+      "output_tokens": 118,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "short",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 80
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 57.8,
+      "decode_tok_s_per_stream": 57.8,
+      "effective_tok_s_incl_ttft": 57.6,
+      "output_tokens": 987,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "reasoning",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 84
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 57.85,
+      "decode_tok_s_per_stream": 57.85,
+      "effective_tok_s_incl_ttft": 57.7,
+      "output_tokens": 1995,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "analytical",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 80
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 50,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 57.75,
+      "decode_tok_s_per_stream": 57.75,
+      "effective_tok_s_incl_ttft": 57.7,
+      "output_tokens": 2500,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "long_2500cap",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 80
+    },
+    {
+      "concurrency": 4,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 155.2,
+      "decode_tok_s_per_stream": 47.2,
+      "effective_tok_s_incl_ttft": 155.2,
+      "output_tokens": 1611,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "reasoning_x4",
+      "samples": 1,
+      "status": "measured",
+      "ttft_ms_p50": 364
+    }
+  ],
+  "schema_version": "local-ai-registry/v1",
+  "source": {
+    "kind": "submitter",
+    "methodology": "OpenAI /v1/chat/completions, streaming (SSE) with usage in the final chunk; temperature 0.7 / top_p 0.8; four prompt classes x 2 runs (short 400 cap, reasoning, analytical, long 2500 cap); effective tok/s = completion_tokens (reasoning + content, from usage) / wall incl. TTFT; TTFT = first streamed delta of content or reasoning; decode tok/s excludes TTFT; 4-way concurrency on the reasoning prompt, aggregate = total completion tokens / batch wall. Idle server, GPUs at the 300 W Max-Q limit. Raw JSON + script in the source repo benchmarks/.",
+    "paths": [
+      "benchmarks/deepseek-v4-flash-0731-tp2-tps-20260826.json"
+    ],
+    "url": "https://github.com/ppickle1989/sm120-sglang-recipes"
+  }
+}

--- a/registry/speed-sweeps/inkling-small-nvfp4-rtxpro6000-sglang-tp2-sweep.json
+++ b/registry/speed-sweeps/inkling-small-nvfp4-rtxpro6000-sglang-tp2-sweep.json
@@ -1,0 +1,92 @@
+{
+  "accepted_at": null,
+  "id": "inkling-small-nvfp4-rtxpro6000-sglang-tp2-sweep",
+  "measured_at": "2026-08-26",
+  "recipe_id": "inkling-small-nvfp4-rtxpro6000-sglang-tp2",
+  "rows": [
+    {
+      "concurrency": 1,
+      "context_tokens": 30,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 117.8,
+      "decode_tok_s_per_stream": 117.8,
+      "effective_tok_s_incl_ttft": 114.7,
+      "output_tokens": 224,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "short",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 60
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 116.0,
+      "decode_tok_s_per_stream": 116.0,
+      "effective_tok_s_incl_ttft": 115.6,
+      "output_tokens": 1528,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "reasoning",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 60
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 115.6,
+      "decode_tok_s_per_stream": 115.6,
+      "effective_tok_s_incl_ttft": 115.2,
+      "output_tokens": 1747,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "analytical",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 63
+    },
+    {
+      "concurrency": 1,
+      "context_tokens": 50,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 115.2,
+      "decode_tok_s_per_stream": 115.2,
+      "effective_tok_s_incl_ttft": 115.0,
+      "output_tokens": 2500,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "long_2500cap",
+      "samples": 2,
+      "status": "measured",
+      "ttft_ms_p50": 62
+    },
+    {
+      "concurrency": 4,
+      "context_tokens": 40,
+      "context_tokens_note": "estimated prompt length (bench JSON records no prompt_tokens)",
+      "decode_tok_s": 306.6,
+      "decode_tok_s_per_stream": 84.2,
+      "effective_tok_s_incl_ttft": 306.6,
+      "output_tokens": 1824,
+      "peak_vram_gb": null,
+      "prefill_tok_s": null,
+      "prompt_class": "reasoning_x4",
+      "samples": 1,
+      "status": "measured",
+      "ttft_ms_p50": 320
+    }
+  ],
+  "schema_version": "local-ai-registry/v1",
+  "source": {
+    "kind": "submitter",
+    "methodology": "OpenAI /v1/chat/completions, streaming (SSE) with usage in the final chunk; temperature 0.7 / top_p 0.8; four prompt classes x 2 runs (short 400 cap, reasoning, analytical, long 2500 cap); effective tok/s = completion_tokens (reasoning + content, from usage) / wall incl. TTFT; TTFT = first streamed delta of content or reasoning; decode tok/s excludes TTFT; 4-way concurrency on the reasoning prompt, aggregate = total completion tokens / batch wall. Idle server, GPUs at the 300 W Max-Q limit. Raw JSON + script in the source repo benchmarks/.",
+    "paths": [
+      "benchmarks/inkling-small-nvfp4-tp2-tps-20260826.json"
+    ],
+    "url": "https://github.com/ppickle1989/sm120-sglang-recipes"
+  }
+}


### PR DESCRIPTION
Two new **candidate** recipes for **2× RTX PRO 6000 Blackwell Max-Q (96 GB, sm_120)** on a consumer AM5 board (ASUS ProArt X870E-Creator, Ryzen 7 9700X), both SGLang TP-2 with 131,072 context. The registry has 4-card and DGX Spark entries for these models but no 2-card RTX PRO 6000 cells.

| recipe | image | patches | single-stream | 4-way | TTFT |
|---|---|---|---|---|---|
| `inkling-small-nvfp4-rtxpro6000-sglang-tp2` | `lmsysorg/sglang:dev-cu13-inkling-dspark@sha256:fbea1a4e…` + 1 patched file → `local/sglang-inkling:sm120` | 2 one-line sm_120 fixes in `inkling_moe.py` (grouped-GEMM `num_stages` 4→3; silu rerouted off Helion to the in-file Triton kernel, verified bit-exact); sha256-asserted at build | ~115 tok/s | 307 tok/s | 0.06 s |
| `deepseek-v4-flash-0731-fp8-fp4-rtxpro6000-sglang-tp2` | same upstream image, stock | none | ~58 tok/s | 155 tok/s | 0.08 s |

**Files:** both shapes — `local-ai/model-instances/*.json` (same key set as the 2026-08-26 GLM entry) and normalized `registry/recipe/*.json` + `registry/speed-sweeps/*-sweep.json` referencing the existing `thinkingmachines-inkling-small-nvfp4--nvfp4` / `deepseek-ai-deepseek-v4-flash-0731--fp8` model-instances and `rtx-pro-6000-blackwell-96gb`. `scripts/curate_registry.py` regenerated `registry/index.json`; `scripts/validate_registry.py` passes (recipe 1039→1041, speed-sweeps 1585→1587). `accepted_at` left null / absent for you to set.

**Source with everything needed to reproduce** (Dockerfile, patch + diff + provenance, run scripts with `--revision` pins, raw benchmark JSON + script): https://github.com/ppickle1989/sm120-sglang-recipes @ `769f470` (MIT; the patched SGLang file under Apache-2.0 with NOTICE).

**Traps recorded in the traces:** stock vLLM v0.27.1 asserts on this model at sm_120 (no attention path) and a ported-attention build computes garbage (cutlass NVFP4 MoE wrong at 256e/top-6) — SGLang + marlin is the coherent path; `NCCL_P2P_DISABLE=1` needed on this board (26-min init hang otherwise); SGLang's DeepSeek-V4 template defaults to chat mode — `chat_template_kwargs {"thinking": true}` per request for thinking mode; PCIe is Gen5 x8 + x4 (consumer lane split, no NVLink), so 2 cards buy concurrency, not single-stream speed.

Happy to adjust shape/fields to whatever you prefer for new submissions.