### PR TITLE
Add audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1 (Local Studio)

### DIFF
--- a/model-instance/audio8-audio8-tts-preview-0-1b.json
+++ b/model-instance/audio8-audio8-tts-preview-0-1b.json
@@ -23,10 +23,10 @@
         {
           "kind": "local-studio",
           "url": "https://github.com/sybil-solutions/local-studio",
-          "captured_at": "2026-08-28T18:11:04.413Z"
+          "captured_at": "2026-08-28T18:11:13.888Z"
         }
       ],
-      "captured_at": "2026-08-28T18:11:04.413Z"
+      "captured_at": "2026-08-28T18:11:13.888Z"
     }
   },
   "provenance": {
@@ -34,10 +34,10 @@
       {
         "kind": "local-studio",
         "url": "https://github.com/sybil-solutions/local-studio",
-        "captured_at": "2026-08-28T18:11:04.413Z"
+        "captured_at": "2026-08-28T18:11:13.888Z"
       }
     ],
-    "captured_at": "2026-08-28T18:11:04.413Z"
+    "captured_at": "2026-08-28T18:11:13.888Z"
   },
   "facts": {
     "revision": {
@@ -48,10 +48,10 @@
           {
             "kind": "local-studio",
             "url": "https://github.com/sybil-solutions/local-studio",
-            "captured_at": "2026-08-28T18:11:04.413Z"
+            "captured_at": "2026-08-28T18:11:13.888Z"
           }
         ],
-        "captured_at": "2026-08-28T18:11:04.413Z"
+        "captured_at": "2026-08-28T18:11:13.888Z"
       }
     },
     "weights.size_gb": {
@@ -62,10 +62,10 @@
           {
             "kind": "local-studio",
             "url": "https://github.com/sybil-solutions/local-studio",
-            "captured_at": "2026-08-28T18:11:04.413Z"
+            "captured_at": "2026-08-28T18:11:13.888Z"
           }
         ],
-        "captured_at": "2026-08-28T18:11:04.413Z"
+        "captured_at": "2026-08-28T18:11:13.888Z"
       }
     }
   }

--- a/model-instance/audio8-audio8-tts-preview-0-1b.json
+++ b/model-instance/audio8-audio8-tts-preview-0-1b.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "local-ai-registry/v1",
+  "id": "audio8-audio8-tts-preview-0-1b",
+  "model_id": "audio8-tts-preview-0-1b",
+  "repository": "Audio8/Audio8-TTS-Preview-0.1b",
+  "url": "https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b",
+  "revision": "b476f0208438dfa791abee44d11029f055aeae04",
+  "served_name": "Audio8-TTS-Preview-0.1b",
+  "weights": {
+    "format": "safetensors",
+    "precision": null,
+    "size_gb": 0.3
+  },
+  "kind": "base",
+  "huggingface": {
+    "link_type": "repository",
+    "status": "unknown",
+    "repository": "Audio8/Audio8-TTS-Preview-0.1b",
+    "url": "https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b",
+    "reason": "not-verified-by-controller",
+    "provenance": {
+      "sources": [
+        {
+          "kind": "local-studio",
+          "url": "https://github.com/sybil-solutions/local-studio",
+          "captured_at": "2026-08-28T18:11:04.413Z"
+        }
+      ],
+      "captured_at": "2026-08-28T18:11:04.413Z"
+    }
+  },
+  "provenance": {
+    "sources": [
+      {
+        "kind": "local-studio",
+        "url": "https://github.com/sybil-solutions/local-studio",
+        "captured_at": "2026-08-28T18:11:04.413Z"
+      }
+    ],
+    "captured_at": "2026-08-28T18:11:04.413Z"
+  },
+  "facts": {
+    "revision": {
+      "state": "known",
+      "value": "b476f0208438dfa791abee44d11029f055aeae04",
+      "provenance": {
+        "sources": [
+          {
+            "kind": "local-studio",
+            "url": "https://github.com/sybil-solutions/local-studio",
+            "captured_at": "2026-08-28T18:11:04.413Z"
+          }
+        ],
+        "captured_at": "2026-08-28T18:11:04.413Z"
+      }
+    },
+    "weights.size_gb": {
+      "state": "known",
+      "value": 0.3,
+      "provenance": {
+        "sources": [
+          {
+            "kind": "local-studio",
+            "url": "https://github.com/sybil-solutions/local-studio",
+            "captured_at": "2026-08-28T18:11:04.413Z"
+          }
+        ],
+        "captured_at": "2026-08-28T18:11:04.413Z"
+      }
+    }
+  }
+}

--- a/model/audio8-tts-preview-0-1b.json
+++ b/model/audio8-tts-preview-0-1b.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "local-ai-registry/v1",
+  "id": "audio8-tts-preview-0-1b",
+  "family": "audio8",
+  "name": "Audio8-TTS-Preview-0.1b",
+  "params": 0.1,
+  "active_params": null,
+  "architecture": null,
+  "url": "https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b",
+  "huggingface": {
+    "link_type": "repository",
+    "status": "unknown",
+    "repository": "Audio8/Audio8-TTS-Preview-0.1b",
+    "url": "https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b",
+    "reason": "not-verified-by-controller",
+    "provenance": {
+      "sources": [
+        {
+          "kind": "local-studio",
+          "url": "https://github.com/sybil-solutions/local-studio",
+          "captured_at": "2026-08-28T18:11:04.413Z"
+        }
+      ],
+      "captured_at": "2026-08-28T18:11:04.413Z"
+    }
+  },
+  "provenance": {
+    "sources": [
+      {
+        "kind": "local-studio",
+        "url": "https://github.com/sybil-solutions/local-studio",
+        "captured_at": "2026-08-28T18:11:04.413Z"
+      }
+    ],
+    "captured_at": "2026-08-28T18:11:04.413Z"
+  },
+  "facts": {}
+}

--- a/model/audio8-tts-preview-0-1b.json
+++ b/model/audio8-tts-preview-0-1b.json
@@ -18,10 +18,10 @@
         {
           "kind": "local-studio",
           "url": "https://github.com/sybil-solutions/local-studio",
-          "captured_at": "2026-08-28T18:11:04.413Z"
+          "captured_at": "2026-08-28T18:11:13.888Z"
         }
       ],
-      "captured_at": "2026-08-28T18:11:04.413Z"
+      "captured_at": "2026-08-28T18:11:13.888Z"
     }
   },
   "provenance": {
@@ -29,10 +29,10 @@
       {
         "kind": "local-studio",
         "url": "https://github.com/sybil-solutions/local-studio",
-        "captured_at": "2026-08-28T18:11:04.413Z"
+        "captured_at": "2026-08-28T18:11:13.888Z"
       }
     ],
-    "captured_at": "2026-08-28T18:11:04.413Z"
+    "captured_at": "2026-08-28T18:11:13.888Z"
   },
   "facts": {}
 }

--- a/recipe/audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1.json
+++ b/recipe/audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1.json
@@ -75,10 +75,10 @@
       {
         "kind": "local-studio",
         "url": "https://github.com/sybil-solutions/local-studio",
-        "captured_at": "2026-08-28T18:11:04.413Z"
+        "captured_at": "2026-08-28T18:11:13.888Z"
       }
     ],
-    "captured_at": "2026-08-28T18:11:04.413Z"
+    "captured_at": "2026-08-28T18:11:13.888Z"
   },
   "facts": {}
 }

--- a/recipe/audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1.json
+++ b/recipe/audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "local-ai-registry/v1",
+  "id": "audio8-tts-preview-0-1b-apple-m4-16gb-vllm-tp1",
+  "recipe_source": "local-studio",
+  "status": "candidate",
+  "description": "Audio8-TTS-Preview-0.1b on 1× Apple M4 16GB via vllm",
+  "model_instance_id": "audio8-audio8-tts-preview-0-1b",
+  "hardware_id": "apple-m4-16gb",
+  "hardware_count": 1,
+  "engine": {
+    "name": "vllm",
+    "version": null,
+    "graph_mode": null
+  },
+  "launch": {
+    "kind": "controller",
+    "accelerator_backend": "metal",
+    "controller": {
+      "recipe_id": "audio8-tts-preview-0-1b",
+      "recipe_name": "Audio8-TTS-Preview-0.1b"
+    },
+    "image": null,
+    "digest": null,
+    "arguments": [
+      "/models",
+      "--served-model-name",
+      "Audio8-TTS-Preview-0.1b",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768",
+      "--gpu-memory-utilization",
+      "0.9",
+      "--max-num-seqs",
+      "256",
+      "--trust-remote-code"
+    ],
+    "container_port": 8000,
+    "host_port": 8000,
+    "environment": {},
+    "mounts": [
+      {
+        "target": "/models",
+        "read_only": true
+      }
+    ]
+  },
+  "serving": {
+    "api": "openai/v1",
+    "tensor_parallel": 1,
+    "pipeline_parallel": 1,
+    "configured_max_context_tokens": 32768,
+    "configured_max_running_sequences": 256,
+    "gpu_memory_utilization": 0.9,
+    "served_model_name": "Audio8-TTS-Preview-0.1b"
+  },
+  "capabilities": {
+    "chat": true,
+    "reasoning": false,
+    "tools": false,
+    "vision": false
+  },
+  "speed_sweeps_ids": [],
+  "metadata": {
+    "local_studio": {
+      "recipe_id": "audio8-tts-preview-0-1b",
+      "recipe_name": "Audio8-TTS-Preview-0.1b",
+      "unmeasured": true
+    }
+  },
+  "provenance": {
+    "sources": [
+      {
+        "kind": "local-studio",
+        "url": "https://github.com/sybil-solutions/local-studio",
+        "captured_at": "2026-08-28T18:11:04.413Z"
+      }
+    ],
+    "captured_at": "2026-08-28T18:11:04.413Z"
+  },
+  "facts": {}
+}


### PR DESCRIPTION
Contribution from Local Studio (recipe "Audio8-TTS-Preview-0.1b").

- hardware: Apple M4 16GB ×1
- engine: vllm
- artifact: `Audio8/Audio8-TTS-Preview-0.1b`
- records validated against the registry JSON Schemas before this PR was opened
- **unmeasured**: shared with the Local Studio demo bypass; no speed evidence yet

Generated by the Local Studio "Share config" flow.