### PR TITLE
Wire hardware → price via derived products[] (T19)

### DIFF
--- a/registry/hardware/apple-m1-16gb.json
+++ b/registry/hardware/apple-m1-16gb.json
@@ -735,12 +735,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 16GB",
-  "products": [
-    "MacBook Air",
-    "MacBook Pro 13-inch",
-    "Mac mini",
-    "iMac 24-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m1-8gb.json
+++ b/registry/hardware/apple-m1-8gb.json
@@ -735,12 +735,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 8GB",
-  "products": [
-    "MacBook Air",
-    "MacBook Pro 13-inch",
-    "Mac mini",
-    "iMac 24-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m1-max-32gb.json
+++ b/registry/hardware/apple-m1-max-32gb.json
@@ -484,9 +484,7 @@
   },
   "name": "Apple M1 Max 32GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m1-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-max-64gb.json
+++ b/registry/hardware/apple-m1-max-64gb.json
@@ -484,9 +484,7 @@
   },
   "name": "Apple M1 Max 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m1-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-pro-16gb.json
+++ b/registry/hardware/apple-m1-pro-16gb.json
@@ -482,10 +482,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Pro 16GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m1-pro-32gb.json
+++ b/registry/hardware/apple-m1-pro-32gb.json
@@ -482,10 +482,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Pro 32GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m1-ultra-128gb.json
+++ b/registry/hardware/apple-m1-ultra-128gb.json
@@ -374,7 +374,7 @@
   },
   "name": "Apple M1 Ultra 128GB",
   "products": [
-    "Mac Studio"
+    "mac-studio-m1-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-ultra-64gb.json
+++ b/registry/hardware/apple-m1-ultra-64gb.json
@@ -374,7 +374,7 @@
   },
   "name": "Apple M1 Ultra 64GB",
   "products": [
-    "Mac Studio"
+    "mac-studio-m1-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-16gb.json
+++ b/registry/hardware/apple-m2-16gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 16GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 13-inch",
-    "Mac mini"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-24gb.json
+++ b/registry/hardware/apple-m2-24gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 24GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 13-inch",
-    "Mac mini"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-8gb.json
+++ b/registry/hardware/apple-m2-8gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 8GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 13-inch",
-    "Mac mini"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-max-32gb.json
+++ b/registry/hardware/apple-m2-max-32gb.json
@@ -484,9 +484,7 @@
   },
   "name": "Apple M2 Max 32GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m2-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-max-64gb.json
+++ b/registry/hardware/apple-m2-max-64gb.json
@@ -484,9 +484,7 @@
   },
   "name": "Apple M2 Max 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m2-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-max-96gb.json
+++ b/registry/hardware/apple-m2-max-96gb.json
@@ -484,9 +484,7 @@
   },
   "name": "Apple M2 Max 96GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m2-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-pro-16gb.json
+++ b/registry/hardware/apple-m2-pro-16gb.json
@@ -499,11 +499,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Pro 16GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac mini"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-pro-32gb.json
+++ b/registry/hardware/apple-m2-pro-32gb.json
@@ -499,11 +499,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Pro 32GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac mini"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-ultra-128gb.json
+++ b/registry/hardware/apple-m2-ultra-128gb.json
@@ -498,10 +498,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 128GB",
-  "products": [
-    "Mac Studio",
-    "Mac Pro"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-ultra-192gb.json
+++ b/registry/hardware/apple-m2-ultra-192gb.json
@@ -498,10 +498,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 192GB",
-  "products": [
-    "Mac Studio",
-    "Mac Pro"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m2-ultra-64gb.json
+++ b/registry/hardware/apple-m2-ultra-64gb.json
@@ -498,10 +498,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 64GB",
-  "products": [
-    "Mac Studio",
-    "Mac Pro"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-16gb.json
+++ b/registry/hardware/apple-m3-16gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 16GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "iMac 24-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-24gb.json
+++ b/registry/hardware/apple-m3-24gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 24GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "iMac 24-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-8gb.json
+++ b/registry/hardware/apple-m3-8gb.json
@@ -624,12 +624,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 8GB",
-  "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "iMac 24-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-max-128gb.json
+++ b/registry/hardware/apple-m3-max-128gb.json
@@ -489,8 +489,7 @@
   },
   "name": "Apple M3 Max 128GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m3-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-max-36gb.json
+++ b/registry/hardware/apple-m3-max-36gb.json
@@ -489,8 +489,7 @@
   },
   "name": "Apple M3 Max 36GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m3-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-max-48gb.json
+++ b/registry/hardware/apple-m3-max-48gb.json
@@ -489,8 +489,7 @@
   },
   "name": "Apple M3 Max 48GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m3-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-max-64gb.json
+++ b/registry/hardware/apple-m3-max-64gb.json
@@ -489,8 +489,7 @@
   },
   "name": "Apple M3 Max 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m3-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-max-96gb.json
+++ b/registry/hardware/apple-m3-max-96gb.json
@@ -489,8 +489,7 @@
   },
   "name": "Apple M3 Max 96GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m3-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-pro-18gb.json
+++ b/registry/hardware/apple-m3-pro-18gb.json
@@ -482,10 +482,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Pro 18GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-pro-36gb.json
+++ b/registry/hardware/apple-m3-pro-36gb.json
@@ -482,10 +482,7 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Pro 36GB",
-  "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
-  ],
+  "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/apple-m3-ultra-256gb.json
+++ b/registry/hardware/apple-m3-ultra-256gb.json
@@ -590,7 +590,7 @@
   },
   "name": "Apple M3 Ultra 256GB",
   "products": [
-    "Mac Studio"
+    "mac-studio-m3-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-ultra-512gb.json
+++ b/registry/hardware/apple-m3-ultra-512gb.json
@@ -590,7 +590,7 @@
   },
   "name": "Apple M3 Ultra 512GB",
   "products": [
-    "Mac Studio"
+    "mac-studio-m3-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-ultra-96gb-60c.json
+++ b/registry/hardware/apple-m3-ultra-96gb-60c.json
@@ -582,7 +582,7 @@
   },
   "name": "Apple M3 Ultra 96GB 60-core GPU",
   "products": [
-    "Mac Studio"
+    "mac-studio-m3-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-ultra-96gb-80c.json
+++ b/registry/hardware/apple-m3-ultra-96gb-80c.json
@@ -593,7 +593,7 @@
   },
   "name": "Apple M3 Ultra 96GB 80-core GPU",
   "products": [
-    "Mac Studio"
+    "mac-studio-m3-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-ultra-96gb.json
+++ b/registry/hardware/apple-m3-ultra-96gb.json
@@ -590,7 +590,7 @@
   },
   "name": "Apple M3 Ultra 96GB",
   "products": [
-    "Mac Studio"
+    "mac-studio-m3-ultra"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-16gb.json
+++ b/registry/hardware/apple-m4-16gb.json
@@ -830,11 +830,7 @@
   },
   "name": "Apple M4 16GB",
   "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "Mac mini",
-    "iMac 24-inch"
+    "mac-mini-m4"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-24gb.json
+++ b/registry/hardware/apple-m4-24gb.json
@@ -830,11 +830,7 @@
   },
   "name": "Apple M4 24GB",
   "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "Mac mini",
-    "iMac 24-inch"
+    "mac-mini-m4"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-32gb.json
+++ b/registry/hardware/apple-m4-32gb.json
@@ -830,11 +830,7 @@
   },
   "name": "Apple M4 32GB",
   "products": [
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch",
-    "MacBook Pro 14-inch",
-    "Mac mini",
-    "iMac 24-inch"
+    "mac-mini-m4"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-max-128gb.json
+++ b/registry/hardware/apple-m4-max-128gb.json
@@ -614,9 +614,8 @@
   },
   "name": "Apple M4 Max 128GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "mac-studio-m4-max",
+    "macbook-pro-m4-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-max-36gb.json
+++ b/registry/hardware/apple-m4-max-36gb.json
@@ -614,9 +614,8 @@
   },
   "name": "Apple M4 Max 36GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "mac-studio-m4-max",
+    "macbook-pro-m4-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-max-48gb.json
+++ b/registry/hardware/apple-m4-max-48gb.json
@@ -614,9 +614,8 @@
   },
   "name": "Apple M4 Max 48GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "mac-studio-m4-max",
+    "macbook-pro-m4-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-max-64gb.json
+++ b/registry/hardware/apple-m4-max-64gb.json
@@ -614,9 +614,8 @@
   },
   "name": "Apple M4 Max 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "mac-studio-m4-max",
+    "macbook-pro-m4-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-pro-24gb.json
+++ b/registry/hardware/apple-m4-pro-24gb.json
@@ -612,9 +612,8 @@
   },
   "name": "Apple M4 Pro 24GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac mini"
+    "mac-mini-m4-pro",
+    "macbook-pro-m4-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-pro-48gb.json
+++ b/registry/hardware/apple-m4-pro-48gb.json
@@ -612,9 +612,8 @@
   },
   "name": "Apple M4 Pro 48GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac mini"
+    "mac-mini-m4-pro",
+    "macbook-pro-m4-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m4-pro-64gb.json
+++ b/registry/hardware/apple-m4-pro-64gb.json
@@ -612,9 +612,8 @@
   },
   "name": "Apple M4 Pro 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac mini"
+    "mac-mini-m4-pro",
+    "macbook-pro-m4-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-16gb.json
+++ b/registry/hardware/apple-m5-16gb.json
@@ -583,9 +583,7 @@
   },
   "name": "Apple M5 16GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch"
+    "macbook-pro-m5"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-24gb.json
+++ b/registry/hardware/apple-m5-24gb.json
@@ -583,9 +583,7 @@
   },
   "name": "Apple M5 24GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch"
+    "macbook-pro-m5"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-32gb.json
+++ b/registry/hardware/apple-m5-32gb.json
@@ -583,9 +583,7 @@
   },
   "name": "Apple M5 32GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Air 13-inch",
-    "MacBook Air 15-inch"
+    "macbook-pro-m5"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-max-128gb.json
+++ b/registry/hardware/apple-m5-max-128gb.json
@@ -614,9 +614,7 @@
   },
   "name": "Apple M5 Max 128GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m5-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-max-36gb.json
+++ b/registry/hardware/apple-m5-max-36gb.json
@@ -614,9 +614,7 @@
   },
   "name": "Apple M5 Max 36GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m5-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-max-48gb.json
+++ b/registry/hardware/apple-m5-max-48gb.json
@@ -614,9 +614,7 @@
   },
   "name": "Apple M5 Max 48GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m5-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-max-64gb.json
+++ b/registry/hardware/apple-m5-max-64gb.json
@@ -614,9 +614,7 @@
   },
   "name": "Apple M5 Max 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch",
-    "Mac Studio"
+    "macbook-pro-m5-max"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-pro-24gb.json
+++ b/registry/hardware/apple-m5-pro-24gb.json
@@ -499,8 +499,7 @@
   },
   "name": "Apple M5 Pro 24GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m5-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-pro-48gb.json
+++ b/registry/hardware/apple-m5-pro-48gb.json
@@ -499,8 +499,7 @@
   },
   "name": "Apple M5 Pro 48GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m5-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m5-pro-64gb.json
+++ b/registry/hardware/apple-m5-pro-64gb.json
@@ -499,8 +499,7 @@
   },
   "name": "Apple M5 Pro 64GB",
   "products": [
-    "MacBook Pro 14-inch",
-    "MacBook Pro 16-inch"
+    "macbook-pro-m5-pro"
   ],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/dgx-spark-gb10-128gb.json
+++ b/registry/hardware/dgx-spark-gb10-128gb.json
@@ -565,7 +565,9 @@
     "vram_type": "LPDDR5X coherent unified system memory"
   },
   "name": "NVIDIA DGX Spark GB10",
-  "products": [],
+  "products": [
+    "dgx-spark"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/intel-arc-pro-b60-24gb.json
+++ b/registry/hardware/intel-arc-pro-b60-24gb.json
@@ -436,7 +436,9 @@
     "vram_type": "GDDR6"
   },
   "name": "Intel Arc Pro B60",
-  "products": [],
+  "products": [
+    "intel-arc-pro-b60"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/intel-arc-pro-b70-32gb.json
+++ b/registry/hardware/intel-arc-pro-b70-32gb.json
@@ -610,7 +610,9 @@
     "vram_type": "GDDR6"
   },
   "name": "Intel Arc Pro B70",
-  "products": [],
+  "products": [
+    "intel-arc-pro-b70"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/radeon-ai-pro-r9700-32gb.json
+++ b/registry/hardware/radeon-ai-pro-r9700-32gb.json
@@ -672,7 +672,9 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon AI PRO R9700",
-  "products": [],
+  "products": [
+    "radeon-ai-pro-r9700"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-2000-ada-16gb.json
+++ b/registry/hardware/rtx-2000-ada-16gb.json
@@ -436,7 +436,9 @@
     "vram_type": "GDDR6"
   },
   "name": "NVIDIA RTX 2000 Ada Generation",
-  "products": [],
+  "products": [
+    "rtx-2000-ada"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3060-12gb.json
+++ b/registry/hardware/rtx-3060-12gb.json
@@ -704,7 +704,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3060",
-  "products": [],
+  "products": [
+    "rtx-3060"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3060-ti-8gb.json
+++ b/registry/hardware/rtx-3060-ti-8gb.json
@@ -572,7 +572,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3060 Ti",
-  "products": [],
+  "products": [
+    "rtx-3060-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3070-8gb.json
+++ b/registry/hardware/rtx-3070-8gb.json
@@ -704,7 +704,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3070",
-  "products": [],
+  "products": [
+    "rtx-3070"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3070-ti-8gb.json
+++ b/registry/hardware/rtx-3070-ti-8gb.json
@@ -572,7 +572,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3070 Ti",
-  "products": [],
+  "products": [
+    "rtx-3070-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3080-10gb.json
+++ b/registry/hardware/rtx-3080-10gb.json
@@ -572,7 +572,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080",
-  "products": [],
+  "products": [
+    "rtx-3080"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3080-12gb.json
+++ b/registry/hardware/rtx-3080-12gb.json
@@ -440,7 +440,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080",
-  "products": [],
+  "products": [
+    "rtx-3080"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3080-ti-12gb.json
+++ b/registry/hardware/rtx-3080-ti-12gb.json
@@ -572,7 +572,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080 Ti",
-  "products": [],
+  "products": [
+    "rtx-3080-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3090-24gb.json
+++ b/registry/hardware/rtx-3090-24gb.json
@@ -572,7 +572,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3090",
-  "products": [],
+  "products": [
+    "rtx-3090"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-3090-ti-24gb.json
+++ b/registry/hardware/rtx-3090-ti-24gb.json
@@ -578,7 +578,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3090 Ti",
-  "products": [],
+  "products": [
+    "rtx-3090-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4000-ada-20gb.json
+++ b/registry/hardware/rtx-4000-ada-20gb.json
@@ -436,7 +436,9 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "NVIDIA RTX 4000 Ada Generation",
-  "products": [],
+  "products": [
+    "rtx-4000-ada"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4060-8gb.json
+++ b/registry/hardware/rtx-4060-8gb.json
@@ -676,7 +676,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060",
-  "products": [],
+  "products": [
+    "rtx-4060"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4060-ti-16gb.json
+++ b/registry/hardware/rtx-4060-ti-16gb.json
@@ -676,7 +676,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060 Ti",
-  "products": [],
+  "products": [
+    "rtx-4060-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4060-ti-8gb.json
+++ b/registry/hardware/rtx-4060-ti-8gb.json
@@ -676,7 +676,9 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060 Ti",
-  "products": [],
+  "products": [
+    "rtx-4060-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4070-12gb.json
+++ b/registry/hardware/rtx-4070-12gb.json
@@ -706,7 +706,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070",
-  "products": [],
+  "products": [
+    "rtx-4070"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4070-super-12gb.json
+++ b/registry/hardware/rtx-4070-super-12gb.json
@@ -550,7 +550,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 SUPER",
-  "products": [],
+  "products": [
+    "rtx-4070-super"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4070-ti-12gb.json
+++ b/registry/hardware/rtx-4070-ti-12gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 Ti",
-  "products": [],
+  "products": [
+    "rtx-4070-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4070-ti-super-16gb.json
+++ b/registry/hardware/rtx-4070-ti-super-16gb.json
@@ -550,7 +550,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 Ti SUPER",
-  "products": [],
+  "products": [
+    "rtx-4070-ti-super"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4080-16gb.json
+++ b/registry/hardware/rtx-4080-16gb.json
@@ -676,7 +676,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4080",
-  "products": [],
+  "products": [
+    "rtx-4080"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4080-super-16gb.json
+++ b/registry/hardware/rtx-4080-super-16gb.json
@@ -550,7 +550,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4080 SUPER",
-  "products": [],
+  "products": [
+    "rtx-4080-super"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-4090-24gb.json
+++ b/registry/hardware/rtx-4090-24gb.json
@@ -676,7 +676,9 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4090",
-  "products": [],
+  "products": [
+    "rtx-4090"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5060-8gb.json
+++ b/registry/hardware/rtx-5060-8gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060",
-  "products": [],
+  "products": [
+    "rtx-5060"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5060-ti-16gb.json
+++ b/registry/hardware/rtx-5060-ti-16gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060 Ti",
-  "products": [],
+  "products": [
+    "rtx-5060-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5060-ti-8gb.json
+++ b/registry/hardware/rtx-5060-ti-8gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060 Ti",
-  "products": [],
+  "products": [
+    "rtx-5060-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5070-12gb.json
+++ b/registry/hardware/rtx-5070-12gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5070",
-  "products": [],
+  "products": [
+    "rtx-5070"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5070-ti-16gb.json
+++ b/registry/hardware/rtx-5070-ti-16gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5070 Ti",
-  "products": [],
+  "products": [
+    "rtx-5070-ti"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5080-16gb.json
+++ b/registry/hardware/rtx-5080-16gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5080",
-  "products": [],
+  "products": [
+    "rtx-5080"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-5090-32gb.json
+++ b/registry/hardware/rtx-5090-32gb.json
@@ -574,7 +574,9 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5090",
-  "products": [],
+  "products": [
+    "rtx-5090"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-6000-ada-48gb.json
+++ b/registry/hardware/rtx-6000-ada-48gb.json
@@ -435,7 +435,9 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "RTX 6000 Ada Generation",
-  "products": [],
+  "products": [
+    "rtx-6000-ada"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-a6000-48gb.json
+++ b/registry/hardware/rtx-a6000-48gb.json
@@ -438,7 +438,9 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "RTX A6000",
-  "products": [],
+  "products": [
+    "rtx-a6000"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-pro-4000-blackwell-24gb.json
+++ b/registry/hardware/rtx-pro-4000-blackwell-24gb.json
@@ -470,7 +470,9 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "NVIDIA RTX PRO 4000 Blackwell",
-  "products": [],
+  "products": [
+    "rtx-pro-4000-blackwell"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-pro-4500-blackwell-32gb.json
+++ b/registry/hardware/rtx-pro-4500-blackwell-32gb.json
@@ -518,7 +518,9 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "NVIDIA RTX PRO 4500 Blackwell",
-  "products": [],
+  "products": [
+    "rtx-pro-4500-blackwell"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rtx-pro-6000-blackwell-96gb.json
+++ b/registry/hardware/rtx-pro-6000-blackwell-96gb.json
@@ -454,7 +454,9 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "RTX PRO 6000 Blackwell",
-  "products": [],
+  "products": [
+    "rtx-pro-6000-blackwell"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rx-7700-xt-12gb.json
+++ b/registry/hardware/rx-7700-xt-12gb.json
@@ -594,7 +594,9 @@
     "vram_type": "GDDR6"
   },
   "name": "AMD Radeon RX 7700 XT",
-  "products": [],
+  "products": [
+    "rx-7700-xt"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rx-7900-xt-20gb.json
+++ b/registry/hardware/rx-7900-xt-20gb.json
@@ -592,7 +592,9 @@
     "vram_type": "GDDR6"
   },
   "name": "AMD Radeon RX 7900 XT",
-  "products": [],
+  "products": [
+    "rx-7900-xt"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rx-7900-xtx-24gb.json
+++ b/registry/hardware/rx-7900-xtx-24gb.json
@@ -594,7 +594,9 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon RX 7900 XTX",
-  "products": [],
+  "products": [
+    "rx-7900-xtx"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/rx-9070-xt-16gb.json
+++ b/registry/hardware/rx-9070-xt-16gb.json
@@ -632,7 +632,9 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon RX 9070 XT",
-  "products": [],
+  "products": [
+    "rx-9070-xt"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/registry/hardware/ryzen-ai-max-plus-395-128gb.json
+++ b/registry/hardware/ryzen-ai-max-plus-395-128gb.json
@@ -452,7 +452,9 @@
     "vram_type": "LPDDR5X unified"
   },
   "name": "Ryzen AI Max+ 395",
-  "products": [],
+  "products": [
+    "amd-strix-halo-mini-pc"
+  ],
   "schema_version": "local-ai-registry/v1",
   "sources": [
     {

--- a/scripts/curate_registry.py
+++ b/scripts/curate_registry.py
@@ -205,6 +205,23 @@ def sanitize_candidates(root):
             write(path, record)
 
 
+
+def link_products(root):
+    """Derive hardware.products from the price records that reference each SKU."""
+    by_hardware = {}
+    for path in sorted((root / "price").glob("*/*.json")):
+        record = json.loads(path.read_text())
+        product_id = record["product"]["id"]
+        for hardware in record.get("hardware", []):
+            by_hardware.setdefault(hardware.get("id"), set()).add(product_id)
+    for path in sorted((root / "hardware").glob("*.json")):
+        record = json.loads(path.read_text())
+        products = sorted(by_hardware.get(record.get("id"), set()))
+        if record.get("products") != products:
+            record["products"] = products
+            write(path, record)
+
+
 def rebuild_index(root):
     collections = {}
     for name in ("hardware", "model", "model-instance", "recipe", "speed-sweep", "benchmark"):
@@ -245,6 +262,7 @@ def main():
     if not args.index_only:
         curate_hardware(root)
         sanitize_candidates(root)
+        link_products(root)
     rebuild_index(root)
 
 

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -378,6 +378,17 @@ def validate(root):
             if not valid_timestamp(observation.get("observed_at")):
                 errors.append(f"{identifier}: observation observed_at must be RFC3339 UTC")
 
+    expected_products = {}
+    for record in prices.values():
+        for hardware in record.get("hardware", []):
+            expected_products.setdefault(hardware.get("id"), set()).add(record["product"]["id"])
+    for record in data["hardware"].values():
+        expected = sorted(expected_products.get(record.get("id"), set()))
+        if record.get("products") != expected:
+            errors.append(
+                f"{record.get('id')}: products {record.get('products')} does not match price records {expected}"
+            )
+
     index_path = root / "index.json"
     try:
         index = json.loads(index_path.read_text())


### PR DESCRIPTION
Closes the hardware→price dead end: `curate_registry.py` derives each hardware record's `products[]` from the price records that reference it (79 SKUs linked), and the validator enforces the round-trip in both directions so the join cannot go stale. Price lookup from a hardware page becomes one hop instead of a 130-file scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)