### PR TITLE
Value-once facts refactor (T16)

### DIFF
--- a/registry/hardware/apple-m1-16gb.json
+++ b/registry/hardware/apple-m1-16gb.json
@@ -43,9 +43,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 999,
@@ -406,12 +410,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 8,
-        "min": 7,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -443,8 +442,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -476,8 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -509,8 +506,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -578,11 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -620,7 +612,7 @@
       },
       "state": "unknown"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -650,10 +642,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -683,10 +674,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -716,13 +706,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air",
-        "MacBook Pro 13-inch",
-        "Mac mini",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m1",
@@ -735,6 +719,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 16GB",
+  "product_names": [
+    "MacBook Air",
+    "MacBook Pro 13-inch",
+    "Mac mini",
+    "iMac 24-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-8gb.json
+++ b/registry/hardware/apple-m1-8gb.json
@@ -43,9 +43,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 999,
@@ -406,12 +410,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 8,
-        "min": 7,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -443,8 +442,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -476,8 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -509,8 +506,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -578,11 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -620,7 +612,7 @@
       },
       "state": "unknown"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -650,10 +642,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -683,10 +674,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -716,13 +706,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air",
-        "MacBook Pro 13-inch",
-        "Mac mini",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m1",
@@ -735,6 +719,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 8GB",
+  "product_names": [
+    "MacBook Air",
+    "MacBook Pro 13-inch",
+    "Mac mini",
+    "iMac 24-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-max-32gb.json
+++ b/registry/hardware/apple-m1-max-32gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 32,
-        "min": 24,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 400
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,12 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-max",
@@ -483,6 +467,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Max 32GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m1-max"
   ],

--- a/registry/hardware/apple-m1-max-64gb.json
+++ b/registry/hardware/apple-m1-max-64gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 32,
-        "min": 24,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 400
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,12 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-max",
@@ -483,6 +467,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Max 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m1-max"
   ],

--- a/registry/hardware/apple-m1-pro-16gb.json
+++ b/registry/hardware/apple-m1-pro-16gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 16,
-        "min": 14,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 200
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-pro",
@@ -482,6 +467,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Pro 16GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-pro-32gb.json
+++ b/registry/hardware/apple-m1-pro-32gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 16,
-        "min": 14,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 200
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-pro",
@@ -482,6 +467,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Pro 32GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m1-ultra-128gb.json
+++ b/registry/hardware/apple-m1-ultra-128gb.json
@@ -25,9 +25,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -212,12 +216,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 64,
-        "min": 48,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -231,8 +230,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -246,8 +244,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -261,8 +258,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -294,11 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -312,10 +304,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -327,10 +318,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -342,10 +332,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -357,10 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-ultra",
@@ -373,6 +359,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Ultra 128GB",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m1-ultra"
   ],

--- a/registry/hardware/apple-m1-ultra-64gb.json
+++ b/registry/hardware/apple-m1-ultra-64gb.json
@@ -25,9 +25,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -212,12 +216,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 64,
-        "min": 48,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -231,8 +230,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -246,8 +244,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -261,8 +258,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -294,11 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -312,10 +304,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -327,10 +318,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -342,10 +332,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -357,10 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m1-ultra",
@@ -373,6 +359,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M1 Ultra 64GB",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m1-ultra"
   ],

--- a/registry/hardware/apple-m2-16gb.json
+++ b/registry/hardware/apple-m2-16gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1199,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 13-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m2",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 16GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 13-inch",
+    "Mac mini"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-24gb.json
+++ b/registry/hardware/apple-m2-24gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1199,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 13-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m2",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 24GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 13-inch",
+    "Mac mini"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-8gb.json
+++ b/registry/hardware/apple-m2-8gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1199,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 13-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m2",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 8GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 13-inch",
+    "Mac mini"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-max-32gb.json
+++ b/registry/hardware/apple-m2-max-32gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 38,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 400
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,12 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-max",
@@ -483,6 +467,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Max 32GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m2-max"
   ],

--- a/registry/hardware/apple-m2-max-64gb.json
+++ b/registry/hardware/apple-m2-max-64gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 38,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 400
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,12 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-max",
@@ -483,6 +467,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Max 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m2-max"
   ],

--- a/registry/hardware/apple-m2-max-96gb.json
+++ b/registry/hardware/apple-m2-max-96gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 38,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 400
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,12 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-max",
@@ -483,6 +467,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Max 96GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m2-max"
   ],

--- a/registry/hardware/apple-m2-pro-16gb.json
+++ b/registry/hardware/apple-m2-pro-16gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1299,
@@ -282,12 +286,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 19,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +306,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +326,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +410,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 200
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +430,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +450,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,12 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-pro",
@@ -499,6 +483,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Pro 16GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac mini"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-pro-32gb.json
+++ b/registry/hardware/apple-m2-pro-32gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1299,
@@ -282,12 +286,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 19,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +306,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +326,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +410,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 200
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +430,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +450,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,12 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-pro",
@@ -499,6 +483,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Pro 32GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac mini"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-ultra-128gb.json
+++ b/registry/hardware/apple-m2-ultra-128gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -282,12 +286,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 76,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +306,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +326,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +410,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +430,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +450,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio",
-        "Mac Pro"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-ultra",
@@ -498,6 +483,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 128GB",
+  "product_names": [
+    "Mac Studio",
+    "Mac Pro"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-ultra-192gb.json
+++ b/registry/hardware/apple-m2-ultra-192gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -282,12 +286,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 76,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +306,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +326,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +410,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +430,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 192
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +450,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio",
-        "Mac Pro"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-ultra",
@@ -498,6 +483,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 192GB",
+  "product_names": [
+    "Mac Studio",
+    "Mac Pro"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m2-ultra-64gb.json
+++ b/registry/hardware/apple-m2-ultra-64gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -282,12 +286,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 76,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +306,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +326,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +410,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +430,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +450,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio",
-        "Mac Pro"
-      ]
+      "state": "known"
     }
   },
   "family": "m2-ultra",
@@ -498,6 +483,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M2 Ultra 64GB",
+  "product_names": [
+    "Mac Studio",
+    "Mac Pro"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-16gb.json
+++ b/registry/hardware/apple-m3-16gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1099,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 16GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "iMac 24-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-24gb.json
+++ b/registry/hardware/apple-m3-24gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1099,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 24GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "iMac 24-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-8gb.json
+++ b/registry/hardware/apple-m3-8gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1099,
@@ -352,12 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -383,8 +382,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -410,8 +408,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -437,8 +434,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -494,11 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 3,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -524,10 +516,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 100
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,10 +542,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,10 +568,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -605,13 +594,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3",
@@ -624,6 +607,12 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 8GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "iMac 24-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-max-128gb.json
+++ b/registry/hardware/apple-m3-max-128gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3199,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,13 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 400,
-        "min": 300
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -447,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -468,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-max",
@@ -488,6 +470,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Max 128GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m3-max"
   ],

--- a/registry/hardware/apple-m3-max-36gb.json
+++ b/registry/hardware/apple-m3-max-36gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3199,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,13 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 400,
-        "min": 300
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 36
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -447,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -468,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-max",
@@ -488,6 +470,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Max 36GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m3-max"
   ],

--- a/registry/hardware/apple-m3-max-48gb.json
+++ b/registry/hardware/apple-m3-max-48gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3199,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,13 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 400,
-        "min": 300
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -447,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -468,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-max",
@@ -488,6 +470,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Max 48GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m3-max"
   ],

--- a/registry/hardware/apple-m3-max-64gb.json
+++ b/registry/hardware/apple-m3-max-64gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3199,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,13 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 400,
-        "min": 300
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -447,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -468,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-max",
@@ -488,6 +470,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Max 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m3-max"
   ],

--- a/registry/hardware/apple-m3-max-96gb.json
+++ b/registry/hardware/apple-m3-max-96gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3199,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 30,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,13 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 400,
-        "min": 300
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -447,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -468,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-max",
@@ -488,6 +470,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Max 96GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m3-max"
   ],

--- a/registry/hardware/apple-m3-pro-18gb.json
+++ b/registry/hardware/apple-m3-pro-18gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 18,
-        "min": 14,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 150
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 18
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-pro",
@@ -482,6 +467,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Pro 18GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-pro-36gb.json
+++ b/registry/hardware/apple-m3-pro-36gb.json
@@ -31,9 +31,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -266,12 +270,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 18,
-        "min": 14,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -291,8 +290,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -312,8 +310,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -333,8 +330,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -378,11 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -402,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 150
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +414,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 36
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -444,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -465,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-pro",
@@ -482,6 +467,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Pro 36GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-m3-ultra-256gb.json
+++ b/registry/hardware/apple-m3-ultra-256gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -320,12 +324,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 80,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -351,8 +350,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -378,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -405,8 +402,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -462,11 +458,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -492,10 +484,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 819
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -519,10 +510,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 256
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -546,10 +536,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -573,10 +562,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-ultra",
@@ -589,6 +575,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Ultra 256GB",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m3-ultra"
   ],

--- a/registry/hardware/apple-m3-ultra-512gb.json
+++ b/registry/hardware/apple-m3-ultra-512gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -320,12 +324,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 80,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -351,8 +350,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -378,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -405,8 +402,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -462,11 +458,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -492,10 +484,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 819
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -519,10 +510,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 512
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -546,10 +536,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -573,10 +562,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-ultra",
@@ -589,6 +575,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Ultra 512GB",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m3-ultra"
   ],

--- a/registry/hardware/apple-m3-ultra-96gb-60c.json
+++ b/registry/hardware/apple-m3-ultra-96gb-60c.json
@@ -34,9 +34,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -316,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 60
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -343,8 +346,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -370,8 +372,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -397,8 +398,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -454,11 +454,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -484,10 +480,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 819
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -511,10 +506,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +532,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +558,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-ultra",
@@ -581,6 +571,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Ultra 96GB 60-core GPU",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m3-ultra"
   ],

--- a/registry/hardware/apple-m3-ultra-96gb-80c.json
+++ b/registry/hardware/apple-m3-ultra-96gb-80c.json
@@ -35,13 +35,13 @@
         ]
       },
       "reason": {
-        "code": "not-applicable",
-        "detail": "Apple pairs 80-core M3 Ultra with 256GB or 512GB; 96GB/80-core is not an Apple commercial configuration."
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
       },
       "scope": "exact 96GB/80-core configuration",
-      "state": "known",
-      "value": "unavailable"
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -322,8 +322,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 80
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -349,8 +348,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -376,8 +374,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -408,8 +405,7 @@
         "detail": "Apple pairs 80-core M3 Ultra with 256GB or 512GB; 96GB/80-core is not an Apple commercial configuration."
       },
       "scope": "exact 96GB/80-core configuration",
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -465,11 +461,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -495,10 +487,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 819
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -522,10 +513,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -549,10 +539,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -576,10 +565,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-ultra",
@@ -592,6 +578,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Ultra 96GB 80-core GPU",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m3-ultra"
   ],

--- a/registry/hardware/apple-m3-ultra-96gb.json
+++ b/registry/hardware/apple-m3-ultra-96gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3999,
@@ -320,12 +324,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 80,
-        "min": 60,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -351,8 +350,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -378,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -405,8 +402,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -462,11 +458,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -492,10 +484,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 819
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -519,10 +510,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -546,10 +536,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -573,10 +562,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m3-ultra",
@@ -589,6 +575,9 @@
     "vram_type": "unified"
   },
   "name": "Apple M3 Ultra 96GB",
+  "product_names": [
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m3-ultra"
   ],

--- a/registry/hardware/apple-m4-16gb.json
+++ b/registry/hardware/apple-m4-16gb.json
@@ -51,9 +51,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 599,
@@ -446,12 +446,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -489,8 +484,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -528,8 +522,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 remains documented/sold in some Mac mini and iMac configurations; M4 MacBook Pro has been superseded.",
@@ -569,8 +562,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -650,11 +642,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -692,10 +680,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 120
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -731,10 +718,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -770,10 +756,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -809,14 +794,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "Mac mini",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m4",
@@ -829,6 +807,13 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 16GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "Mac mini",
+    "iMac 24-inch"
+  ],
   "products": [
     "mac-mini-m4"
   ],

--- a/registry/hardware/apple-m4-24gb.json
+++ b/registry/hardware/apple-m4-24gb.json
@@ -51,9 +51,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 599,
@@ -446,12 +446,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -489,8 +484,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -528,8 +522,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 remains documented/sold in some Mac mini and iMac configurations; M4 MacBook Pro has been superseded.",
@@ -569,8 +562,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -650,11 +642,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -692,10 +680,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 120
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -731,10 +718,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -770,10 +756,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -809,14 +794,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "Mac mini",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m4",
@@ -829,6 +807,13 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 24GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "Mac mini",
+    "iMac 24-inch"
+  ],
   "products": [
     "mac-mini-m4"
   ],

--- a/registry/hardware/apple-m4-32gb.json
+++ b/registry/hardware/apple-m4-32gb.json
@@ -51,9 +51,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 599,
@@ -446,12 +446,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 10,
-        "min": 8,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -489,8 +484,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -528,8 +522,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 remains documented/sold in some Mac mini and iMac configurations; M4 MacBook Pro has been superseded.",
@@ -569,8 +562,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -650,11 +642,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -692,10 +680,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 120
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -731,10 +718,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -770,10 +756,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -809,14 +794,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch",
-        "MacBook Pro 14-inch",
-        "Mac mini",
-        "iMac 24-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m4",
@@ -829,6 +807,13 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 32GB",
+  "product_names": [
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch",
+    "MacBook Pro 14-inch",
+    "Mac mini",
+    "iMac 24-inch"
+  ],
   "products": [
     "mac-mini-m4"
   ],

--- a/registry/hardware/apple-m4-max-128gb.json
+++ b/registry/hardware/apple-m4-max-128gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -336,12 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +366,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +392,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 546,
-        "min": 410
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-max",
@@ -613,6 +594,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Max 128GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m4-max",
     "macbook-pro-m4-max"

--- a/registry/hardware/apple-m4-max-36gb.json
+++ b/registry/hardware/apple-m4-max-36gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -336,12 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +366,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +392,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 546,
-        "min": 410
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 36
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-max",
@@ -613,6 +594,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Max 36GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m4-max",
     "macbook-pro-m4-max"

--- a/registry/hardware/apple-m4-max-48gb.json
+++ b/registry/hardware/apple-m4-max-48gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -336,12 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +366,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +392,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 546,
-        "min": 410
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-max",
@@ -613,6 +594,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Max 48GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m4-max",
     "macbook-pro-m4-max"

--- a/registry/hardware/apple-m4-max-64gb.json
+++ b/registry/hardware/apple-m4-max-64gb.json
@@ -37,9 +37,13 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "reason": {
+        "code": "not-currently-sold",
+        "detail": "Audited vendor sources indicate this configuration is not offered for sale new; state promoted from the facts entry during the value-once migration."
+      },
+      "state": "unavailable"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1999,
@@ -336,12 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +366,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +392,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unavailable"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 546,
-        "min": 410
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-max",
@@ -613,6 +594,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Max 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "mac-studio-m4-max",
     "macbook-pro-m4-max"

--- a/registry/hardware/apple-m4-pro-24gb.json
+++ b/registry/hardware/apple-m4-pro-24gb.json
@@ -39,9 +39,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1399,
@@ -338,12 +338,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -369,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -396,8 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 Pro remains documented/sold in Mac mini in the current catalog; MacBook Pro configurations have been superseded.",
@@ -425,8 +418,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -482,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -512,10 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 273
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -566,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -593,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-pro",
@@ -611,6 +591,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Pro 24GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac mini"
+  ],
   "products": [
     "mac-mini-m4-pro",
     "macbook-pro-m4-pro"

--- a/registry/hardware/apple-m4-pro-48gb.json
+++ b/registry/hardware/apple-m4-pro-48gb.json
@@ -39,9 +39,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1399,
@@ -338,12 +338,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -369,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -396,8 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 Pro remains documented/sold in Mac mini in the current catalog; MacBook Pro configurations have been superseded.",
@@ -425,8 +418,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -482,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -512,10 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 273
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -566,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -593,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-pro",
@@ -611,6 +591,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Pro 48GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac mini"
+  ],
   "products": [
     "mac-mini-m4-pro",
     "macbook-pro-m4-pro"

--- a/registry/hardware/apple-m4-pro-64gb.json
+++ b/registry/hardware/apple-m4-pro-64gb.json
@@ -39,9 +39,9 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1399,
@@ -338,12 +338,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -369,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -396,8 +390,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "note": "M4 Pro remains documented/sold in Mac mini in the current catalog; MacBook Pro configurations have been superseded.",
@@ -425,8 +418,7 @@
         ]
       },
       "scope": "some listed product/form factors",
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -482,11 +474,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -512,10 +500,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 273
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +526,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -566,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -593,12 +578,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac mini"
-      ]
+      "state": "known"
     }
   },
   "family": "m4-pro",
@@ -611,6 +591,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M4 Pro 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac mini"
+  ],
   "products": [
     "mac-mini-m4-pro",
     "macbook-pro-m4-pro"

--- a/registry/hardware/apple-m5-16gb.json
+++ b/registry/hardware/apple-m5-16gb.json
@@ -33,9 +33,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1699,
@@ -315,8 +315,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -342,8 +341,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -369,8 +367,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -396,8 +393,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -453,11 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -483,10 +475,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 153
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -510,10 +501,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +527,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -564,12 +553,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5",
@@ -582,6 +566,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 16GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch"
+  ],
   "products": [
     "macbook-pro-m5"
   ],

--- a/registry/hardware/apple-m5-24gb.json
+++ b/registry/hardware/apple-m5-24gb.json
@@ -33,9 +33,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1699,
@@ -315,8 +315,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -342,8 +341,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -369,8 +367,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -396,8 +393,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -453,11 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -483,10 +475,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 153
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -510,10 +501,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +527,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -564,12 +553,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5",
@@ -582,6 +566,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 24GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch"
+  ],
   "products": [
     "macbook-pro-m5"
   ],

--- a/registry/hardware/apple-m5-32gb.json
+++ b/registry/hardware/apple-m5-32gb.json
@@ -33,9 +33,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 1699,
@@ -315,8 +315,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -342,8 +341,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -369,8 +367,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -396,8 +393,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -453,11 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -483,10 +475,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 153
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -510,10 +501,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +527,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -564,12 +553,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Air 13-inch",
-        "MacBook Air 15-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5",
@@ -582,6 +566,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 32GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Air 13-inch",
+    "MacBook Air 15-inch"
+  ],
   "products": [
     "macbook-pro-m5"
   ],

--- a/registry/hardware/apple-m5-max-128gb.json
+++ b/registry/hardware/apple-m5-max-128gb.json
@@ -37,9 +37,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3599,
@@ -336,12 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +388,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +414,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +496,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 614,
-        "min": 460
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +522,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +548,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-max",
@@ -613,6 +590,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Max 128GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m5-max"
   ],

--- a/registry/hardware/apple-m5-max-36gb.json
+++ b/registry/hardware/apple-m5-max-36gb.json
@@ -37,9 +37,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3599,
@@ -336,12 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +388,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +414,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +496,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 614,
-        "min": 460
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +522,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 36
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +548,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-max",
@@ -613,6 +590,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Max 36GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m5-max"
   ],

--- a/registry/hardware/apple-m5-max-48gb.json
+++ b/registry/hardware/apple-m5-max-48gb.json
@@ -37,9 +37,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3599,
@@ -336,12 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +388,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +414,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +496,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 614,
-        "min": 460
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +522,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +548,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-max",
@@ -613,6 +590,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Max 48GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m5-max"
   ],

--- a/registry/hardware/apple-m5-max-64gb.json
+++ b/registry/hardware/apple-m5-max-64gb.json
@@ -37,9 +37,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 3599,
@@ -336,12 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 40,
-        "min": 32,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -367,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -394,8 +388,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -421,8 +414,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -478,11 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -508,13 +496,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 614,
-        "min": 460
-      }
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -538,10 +522,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -565,10 +548,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -592,12 +574,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch",
-        "Mac Studio"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-max",
@@ -613,6 +590,11 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Max 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch",
+    "Mac Studio"
+  ],
   "products": [
     "macbook-pro-m5-max"
   ],

--- a/registry/hardware/apple-m5-pro-24gb.json
+++ b/registry/hardware/apple-m5-pro-24gb.json
@@ -31,9 +31,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 2199,
@@ -282,12 +282,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +302,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +322,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +342,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +386,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +406,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 307
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +426,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +446,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +466,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-pro",
@@ -498,6 +479,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Pro 24GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m5-pro"
   ],

--- a/registry/hardware/apple-m5-pro-48gb.json
+++ b/registry/hardware/apple-m5-pro-48gb.json
@@ -31,9 +31,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 2199,
@@ -282,12 +282,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +302,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +322,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +342,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +386,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +406,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 307
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +426,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +446,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +466,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-pro",
@@ -498,6 +479,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Pro 48GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m5-pro"
   ],

--- a/registry/hardware/apple-m5-pro-64gb.json
+++ b/registry/hardware/apple-m5-pro-64gb.json
@@ -31,9 +31,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "exact_configuration_price": null,
     "prices": [
       {
         "amount": 2199,
@@ -282,12 +282,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "max": 20,
-        "min": 16,
-        "variant_note": "Memory-only registry ID spans Apple GPU variants."
-      }
+      "state": "known"
     },
     "accelerator.neural_engine_cores": {
       "provenance": {
@@ -307,8 +302,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
     "accelerator_backend": {
       "provenance": {
@@ -328,8 +322,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -349,8 +342,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.exact_configuration_price": {
       "provenance": {
@@ -394,11 +386,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 2,
-        "scope": "representative_product_starting_price"
-      }
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -418,10 +406,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 307
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -439,10 +426,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -460,10 +446,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -481,11 +466,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": [
-        "MacBook Pro 14-inch",
-        "MacBook Pro 16-inch"
-      ]
+      "state": "known"
     }
   },
   "family": "m5-pro",
@@ -498,6 +479,10 @@
     "vram_type": "unified"
   },
   "name": "Apple M5 Pro 64GB",
+  "product_names": [
+    "MacBook Pro 14-inch",
+    "MacBook Pro 16-inch"
+  ],
   "products": [
     "macbook-pro-m5-pro"
   ],

--- a/registry/hardware/apple-max-128gb.json
+++ b/registry/hardware/apple-max-128gb.json
@@ -227,8 +227,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -284,7 +283,7 @@
       },
       "state": "unknown"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -296,10 +295,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -311,10 +309,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -343,6 +340,7 @@
     "vram_type": "unified"
   },
   "name": "Apple Max 128GB, generation unspecified",
+  "product_names": [],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/apple-pro-64gb.json
+++ b/registry/hardware/apple-pro-64gb.json
@@ -227,8 +227,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "metal"
+      "state": "known"
     },
     "commercial.availability": {
       "provenance": {
@@ -284,7 +283,7 @@
       },
       "state": "unknown"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -296,10 +295,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -311,10 +309,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": "unified"
+      "state": "known"
     },
-    "products": {
+    "product_names": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -343,6 +340,7 @@
     "vram_type": "unified"
   },
   "name": "Apple Pro 64GB, generation unspecified",
+  "product_names": [],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/b200-180gb.json
+++ b/registry/hardware/b200-180gb.json
@@ -26,13 +26,20 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "channel_status": "partner_system_only",
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
     "architecture": "NVIDIA Blackwell",
+    "cuda_cores": null,
+    "fp4_tflops": {
+      "dense": 9000,
+      "structured_2_4": 18000
+    },
     "stats": {
       "bf16": {
         "dense": {
@@ -352,8 +359,7 @@
       },
       "scope": "individual SXM6 accelerator",
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -397,8 +403,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -418,8 +423,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_system_only"
+      "state": "known"
     },
     "commercial.current_street_price": {
       "provenance": {
@@ -511,8 +515,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -557,11 +560,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": {
-        "dense": 9000,
-        "structured_2_4": 18000
-      }
+      "unit": "tflops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -581,10 +580,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 7700
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -602,10 +600,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 180
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -623,8 +620,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "HBM3e"
+      "state": "known"
     }
   },
   "family": "b200",
@@ -637,6 +633,7 @@
     "vram_type": "HBM3e"
   },
   "name": "NVIDIA B200",
+  "product_names": [],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/dgx-spark-gb10-128gb.json
+++ b/registry/hardware/dgx-spark-gb10-128gb.json
@@ -25,8 +25,12 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
+    },
+    "channel_status": "available",
+    "current_system_price": {
+      "amount": 4699,
+      "currency": "USD"
     },
     "prices": [
       {
@@ -50,6 +54,9 @@
     "architecture": "NVIDIA Grace Blackwell GB10",
     "cpu_cores": 20,
     "cuda_cores": 6144,
+    "fp4_tflops": {
+      "structured_2_4": 1000
+    },
     "stats": {
       "bf16": {
         "unknown": {
@@ -286,8 +293,7 @@
         ]
       },
       "state": "known",
-      "unit": "integrated GPU",
-      "value": 1
+      "unit": "integrated GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -331,8 +337,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -352,8 +357,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.current_system_price": {
       "provenance": {
@@ -374,11 +378,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 4699,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -398,11 +398,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "observed_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -422,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Grace Blackwell GB10"
+      "state": "known"
     },
     "compute.cpu_cores": {
       "provenance": {
@@ -443,8 +438,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 20
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -464,8 +458,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 6144
+      "state": "known"
     },
     "compute.fp4_tflops": {
       "provenance": {
@@ -486,10 +479,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": {
-        "structured_2_4": 1000
-      }
+      "unit": "tflops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -509,10 +499,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 273
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -530,10 +519,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -551,8 +539,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "LPDDR5X coherent unified system memory"
+      "state": "known"
     }
   },
   "family": "dgx-spark-gb10",
@@ -565,6 +552,7 @@
     "vram_type": "LPDDR5X coherent unified system memory"
   },
   "name": "NVIDIA DGX Spark GB10",
+  "product_names": [],
   "products": [
     "dgx-spark"
   ],

--- a/registry/hardware/intel-arc-pro-b60-24gb.json
+++ b/registry/hardware/intel-arc-pro-b60-24gb.json
@@ -25,10 +25,14 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_aib_only",
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
     "architecture": "Intel Xe2 Battlemage",
+    "int8_tops": 197,
     "stats": {
       "bf16": {
         "unknown": {
@@ -211,8 +215,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -262,8 +265,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_aib_only"
+      "state": "known"
     },
     "commercial.current_street_price": {
       "provenance": {
@@ -331,8 +333,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "Intel Xe2 Battlemage"
+      "state": "known"
     },
     "compute.int8_tops": {
       "provenance": {
@@ -347,8 +348,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 197
+      "unit": "tops"
     },
     "compute.xe_cores": {
       "provenance": {
@@ -362,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 20
+      "state": "known"
     },
     "compute.xmx_engines": {
       "provenance": {
@@ -377,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 160
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -392,10 +390,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 456
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -407,10 +404,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -422,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "intel-arc-pro-b60",
@@ -436,6 +431,7 @@
     "vram_type": "GDDR6"
   },
   "name": "Intel Arc Pro B60",
+  "product_names": [],
   "products": [
     "intel-arc-pro-b60"
   ],

--- a/registry/hardware/intel-arc-pro-b70-32gb.json
+++ b/registry/hardware/intel-arc-pro-b70-32gb.json
@@ -25,8 +25,14 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
+    },
+    "channel_status": "launched_partner_and_intel_card",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 949,
+      "currency": "USD"
     },
     "prices": [
       {
@@ -49,6 +55,7 @@
   },
   "compute": {
     "architecture": "Intel Xe2 Battlemage",
+    "int8_tops": 367,
     "stats": {
       "bf16": {
         "unknown": {
@@ -285,8 +292,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -330,8 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -351,8 +356,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "launched_partner_and_intel_card"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -421,11 +425,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 949,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -445,11 +445,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -469,8 +465,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "Intel Xe2 Battlemage"
+      "state": "known"
     },
     "compute.int8_tops": {
       "provenance": {
@@ -491,8 +486,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 367
+      "unit": "tops"
     },
     "compute.xe_cores": {
       "provenance": {
@@ -512,8 +506,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
     "compute.xmx_engines": {
       "provenance": {
@@ -533,8 +526,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 256
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -554,10 +546,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 608
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -575,10 +566,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -596,8 +586,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "intel-arc-pro-b70",
@@ -610,6 +599,7 @@
     "vram_type": "GDDR6"
   },
   "name": "Intel Arc Pro B70",
+  "product_names": [],
   "products": [
     "intel-arc-pro-b70"
   ],

--- a/registry/hardware/mi300x-192gb.json
+++ b/registry/hardware/mi300x-192gb.json
@@ -19,9 +19,11 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "channel_status": "server_oem_platform",
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -248,8 +250,7 @@
         ]
       },
       "state": "known",
-      "unit": "OAM accelerator",
-      "value": 1
+      "unit": "OAM accelerator"
     },
     "audit.unresolved": {
       "provenance": {
@@ -281,8 +282,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -296,8 +296,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "server_oem_platform"
+      "state": "known"
     },
     "commercial.current_street_price": {
       "provenance": {
@@ -365,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD CDNA 3"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -380,8 +378,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 304
+      "state": "known"
     },
     "compute.matrix_cores": {
       "provenance": {
@@ -395,8 +392,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 1216
+      "state": "known"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -410,8 +406,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 19456
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -425,10 +420,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 5300
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -440,10 +434,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 192
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -455,8 +448,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "HBM3"
+      "state": "known"
     }
   },
   "family": "mi300x",
@@ -469,6 +461,7 @@
     "vram_type": "HBM3"
   },
   "name": "AMD Instinct MI300X",
+  "product_names": [],
   "products": [],
   "schema_version": "local-ai-registry/v1",
   "sources": [

--- a/registry/hardware/radeon-ai-pro-r9700-32gb.json
+++ b/registry/hardware/radeon-ai-pro-r9700-32gb.json
@@ -27,8 +27,14 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
+    },
+    "channel_status": "partner_workstation_systems",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1299,
+      "currency": "USD"
     },
     "prices": [
       {
@@ -53,6 +59,7 @@
     "ai_accelerators": 128,
     "architecture": "AMD RDNA 4",
     "compute_units": 64,
+    "int4_tops": 1531,
     "stats": {
       "bf16": {
         "unknown": {
@@ -326,8 +333,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -371,8 +377,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -392,8 +397,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_workstation_systems"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -462,11 +466,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1299,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -486,11 +486,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.ai_accelerators": {
       "provenance": {
@@ -510,8 +506,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -531,8 +526,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD RDNA 4"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -552,8 +546,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
     "compute.int4_tops": {
       "provenance": {
@@ -574,8 +567,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 1531
+      "unit": "tops"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -595,8 +587,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4096
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -616,10 +607,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 640
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -637,10 +627,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -658,8 +647,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "radeon-ai-pro-r9700",
@@ -672,6 +660,7 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon AI PRO R9700",
+  "product_names": [],
   "products": [
     "radeon-ai-pro-r9700"
   ],

--- a/registry/hardware/rtx-2000-ada-16gb.json
+++ b/registry/hardware/rtx-2000-ada-16gb.json
@@ -25,6 +25,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -212,8 +216,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -245,8 +248,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -332,8 +334,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -347,8 +348,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 2816
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -362,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 22
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -377,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 88
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -392,10 +390,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 224
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -407,10 +404,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -422,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-2000-ada",
@@ -436,6 +431,7 @@
     "vram_type": "GDDR6"
   },
   "name": "NVIDIA RTX 2000 Ada Generation",
+  "product_names": [],
   "products": [
     "rtx-2000-ada"
   ],

--- a/registry/hardware/rtx-3060-12gb.json
+++ b/registry/hardware/rtx-3060-12gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 329,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 329,
@@ -323,8 +330,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -380,8 +386,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -468,11 +473,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 329,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -498,11 +499,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -528,8 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -555,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 3584
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -582,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -609,8 +603,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -636,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 360
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -663,10 +655,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -690,8 +681,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-3060",
@@ -704,6 +694,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3060",
+  "product_names": [],
   "products": [
     "rtx-3060"
   ],

--- a/registry/hardware/rtx-3060-ti-8gb.json
+++ b/registry/hardware/rtx-3060-ti-8gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 399,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 399,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 399,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4864
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -474,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -495,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -516,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 448
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +529,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -558,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-3060-ti",
@@ -572,6 +562,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3060 Ti",
+  "product_names": [],
   "products": [
     "rtx-3060-ti"
   ],

--- a/registry/hardware/rtx-3070-8gb.json
+++ b/registry/hardware/rtx-3070-8gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 499,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 499,
@@ -323,8 +330,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -380,8 +386,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -468,11 +473,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 499,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -498,11 +499,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -528,8 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -555,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 5888
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -582,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -609,8 +603,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -636,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 448
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -663,10 +655,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -690,8 +681,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-3070",
@@ -704,6 +694,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 3070",
+  "product_names": [],
   "products": [
     "rtx-3070"
   ],

--- a/registry/hardware/rtx-3070-ti-8gb.json
+++ b/registry/hardware/rtx-3070-ti-8gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 599,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 599,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 599,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 6144
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -474,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -495,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -516,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 608
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +529,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -558,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3070-ti",
@@ -572,6 +562,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3070 Ti",
+  "product_names": [],
   "products": [
     "rtx-3070-ti"
   ],

--- a/registry/hardware/rtx-3080-10gb.json
+++ b/registry/hardware/rtx-3080-10gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 699,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 699,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 699,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8704
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -474,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -495,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -516,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 760
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +529,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -558,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3080",
@@ -572,6 +562,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080",
+  "product_names": [],
   "products": [
     "rtx-3080"
   ],

--- a/registry/hardware/rtx-3080-12gb.json
+++ b/registry/hardware/rtx-3080-12gb.json
@@ -27,6 +27,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -198,8 +202,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -249,8 +252,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -336,8 +338,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -351,8 +352,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8960
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -366,8 +366,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -381,8 +380,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -396,10 +394,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 912
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -411,10 +408,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -426,8 +422,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3080",
@@ -440,6 +435,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080",
+  "product_names": [],
   "products": [
     "rtx-3080"
   ],

--- a/registry/hardware/rtx-3080-ti-12gb.json
+++ b/registry/hardware/rtx-3080-ti-12gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1199,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 1199,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1199,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10240
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -474,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -495,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -516,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 912
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +529,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -558,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3080-ti",
@@ -572,6 +562,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3080 Ti",
+  "product_names": [],
   "products": [
     "rtx-3080-ti"
   ],

--- a/registry/hardware/rtx-3090-24gb.json
+++ b/registry/hardware/rtx-3090-24gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1499,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 1499,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1499,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10496
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -474,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -495,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -516,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 936
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -537,10 +529,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -558,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3090",
@@ -572,6 +562,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3090",
+  "product_names": [],
   "products": [
     "rtx-3090"
   ],

--- a/registry/hardware/rtx-3090-ti-24gb.json
+++ b/registry/hardware/rtx-3090-ti-24gb.json
@@ -33,6 +33,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -252,8 +256,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -321,8 +324,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -438,8 +440,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -459,8 +460,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10752
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -480,8 +480,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "2nd generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -501,8 +500,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "3rd generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -522,10 +520,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 1008
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -543,10 +540,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -564,8 +560,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-3090-ti",
@@ -578,6 +573,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 3090 Ti",
+  "product_names": [],
   "products": [
     "rtx-3090-ti"
   ],

--- a/registry/hardware/rtx-4000-ada-20gb.json
+++ b/registry/hardware/rtx-4000-ada-20gb.json
@@ -25,6 +25,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -212,8 +216,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -245,8 +248,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -332,8 +334,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -347,8 +348,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 6144
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -362,8 +362,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -377,8 +376,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 192
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -392,10 +390,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 360
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -407,10 +404,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 20
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -422,8 +418,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-4000-ada",
@@ -436,6 +431,7 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "NVIDIA RTX 4000 Ada Generation",
+  "product_names": [],
   "products": [
     "rtx-4000-ada"
   ],

--- a/registry/hardware/rtx-4060-8gb.json
+++ b/registry/hardware/rtx-4060-8gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 299,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 299,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -406,8 +412,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -494,11 +499,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 299,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -524,11 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -554,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -581,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 3072
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -608,10 +603,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 272
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -635,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -662,8 +655,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-4060",
@@ -676,6 +668,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060",
+  "product_names": [],
   "products": [
     "rtx-4060"
   ],

--- a/registry/hardware/rtx-4060-ti-16gb.json
+++ b/registry/hardware/rtx-4060-ti-16gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 499,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 499,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -406,8 +412,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -494,11 +499,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 499,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -524,11 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -554,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -581,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4352
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -608,10 +603,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 288
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -635,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -662,8 +655,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-4060-ti",
@@ -676,6 +668,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060 Ti",
+  "product_names": [],
   "products": [
     "rtx-4060-ti"
   ],

--- a/registry/hardware/rtx-4060-ti-8gb.json
+++ b/registry/hardware/rtx-4060-ti-8gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 399,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 399,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -406,8 +412,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -494,11 +499,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 399,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -524,11 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -554,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -581,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4352
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -608,10 +603,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 288
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -635,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -662,8 +655,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rtx-4060-ti",
@@ -676,6 +668,7 @@
     "vram_type": "GDDR6"
   },
   "name": "GeForce RTX 4060 Ti",
+  "product_names": [],
   "products": [
     "rtx-4060-ti"
   ],

--- a/registry/hardware/rtx-4070-12gb.json
+++ b/registry/hardware/rtx-4070-12gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 599,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 599,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -436,8 +442,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -524,11 +529,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 599,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -554,11 +555,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -584,8 +581,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -611,8 +607,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 5888
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -638,10 +633,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 504
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -665,10 +659,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -692,8 +685,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4070",
@@ -706,6 +698,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070",
+  "product_names": [],
   "products": [
     "rtx-4070"
   ],

--- a/registry/hardware/rtx-4070-super-12gb.json
+++ b/registry/hardware/rtx-4070-super-12gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 599,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 599,
@@ -289,8 +296,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -334,8 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -404,11 +409,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 599,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -428,11 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -452,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -473,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 7168
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -494,10 +489,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 504
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -515,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -536,8 +529,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4070-super",
@@ -550,6 +542,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 SUPER",
+  "product_names": [],
   "products": [
     "rtx-4070-super"
   ],

--- a/registry/hardware/rtx-4070-ti-12gb.json
+++ b/registry/hardware/rtx-4070-ti-12gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 799,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 799,
@@ -289,8 +296,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -358,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -428,11 +433,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 799,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -452,11 +453,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -476,8 +473,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -497,8 +493,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 7680
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +513,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 504
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +533,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +553,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4070-ti",
@@ -574,6 +566,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 Ti",
+  "product_names": [],
   "products": [
     "rtx-4070-ti"
   ],

--- a/registry/hardware/rtx-4070-ti-super-16gb.json
+++ b/registry/hardware/rtx-4070-ti-super-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 799,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 799,
@@ -289,8 +296,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -334,8 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -404,11 +409,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 799,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -428,11 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -452,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -473,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8448
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -494,10 +489,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 672
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -515,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -536,8 +529,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4070-ti-super",
@@ -550,6 +542,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4070 Ti SUPER",
+  "product_names": [],
   "products": [
     "rtx-4070-ti-super"
   ],

--- a/registry/hardware/rtx-4080-16gb.json
+++ b/registry/hardware/rtx-4080-16gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1199,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 1199,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -406,8 +412,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -494,11 +499,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1199,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -524,11 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -554,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -581,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 9728
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -608,10 +603,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 717
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -635,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -662,8 +655,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4080",
@@ -676,6 +668,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4080",
+  "product_names": [],
   "products": [
     "rtx-4080"
   ],

--- a/registry/hardware/rtx-4080-super-16gb.json
+++ b/registry/hardware/rtx-4080-super-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 999,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 999,
@@ -289,8 +296,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -334,8 +340,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -404,11 +409,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 999,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -428,11 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -452,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -473,8 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10240
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -494,10 +489,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 736
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -515,10 +509,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -536,8 +529,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4080-super",
@@ -550,6 +542,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4080 SUPER",
+  "product_names": [],
   "products": [
     "rtx-4080-super"
   ],

--- a/registry/hardware/rtx-4090-24gb.json
+++ b/registry/hardware/rtx-4090-24gb.json
@@ -39,6 +39,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_vendor_catalog",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1599,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 1599,
@@ -349,8 +356,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -406,8 +412,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_vendor_catalog"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -494,11 +499,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1599,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -524,11 +525,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -554,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -581,8 +577,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16384
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -608,10 +603,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 1008
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -635,10 +629,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -662,8 +655,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6X"
+      "state": "known"
     }
   },
   "family": "rtx-4090",
@@ -676,6 +668,7 @@
     "vram_type": "GDDR6X"
   },
   "name": "GeForce RTX 4090",
+  "product_names": [],
   "products": [
     "rtx-4090"
   ],

--- a/registry/hardware/rtx-5060-8gb.json
+++ b/registry/hardware/rtx-5060-8gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 299,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 299,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 299,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 3840
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 58
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 614
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 448
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5060",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060",
+  "product_names": [],
   "products": [
     "rtx-5060"
   ],

--- a/registry/hardware/rtx-5060-ti-16gb.json
+++ b/registry/hardware/rtx-5060-ti-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 429,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 429,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 429,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4608
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 72
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 759
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 448
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5060-ti",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060 Ti",
+  "product_names": [],
   "products": [
     "rtx-5060-ti"
   ],

--- a/registry/hardware/rtx-5060-ti-8gb.json
+++ b/registry/hardware/rtx-5060-ti-8gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 379,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 379,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 379,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4608
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 72
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 759
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 448
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5060-ti",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5060 Ti",
+  "product_names": [],
   "products": [
     "rtx-5060-ti"
   ],

--- a/registry/hardware/rtx-5070-12gb.json
+++ b/registry/hardware/rtx-5070-12gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 549,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 549,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 549,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 6144
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 94
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 988
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 672
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5070",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5070",
+  "product_names": [],
   "products": [
     "rtx-5070"
   ],

--- a/registry/hardware/rtx-5070-ti-16gb.json
+++ b/registry/hardware/rtx-5070-ti-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 749,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 749,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 749,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8960
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 133
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 1406
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 896
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5070-ti",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5070 Ti",
+  "product_names": [],
   "products": [
     "rtx-5070-ti"
   ],

--- a/registry/hardware/rtx-5080-16gb.json
+++ b/registry/hardware/rtx-5080-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 999,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 999,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 999,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10752
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 171
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 1801
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 960
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5080",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5080",
+  "product_names": [],
   "products": [
     "rtx-5080"
   ],

--- a/registry/hardware/rtx-5090-32gb.json
+++ b/registry/hardware/rtx-5090-32gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 1999,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 1999,
@@ -269,8 +276,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -314,8 +320,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -384,11 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 1999,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -408,11 +409,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -432,8 +429,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -453,8 +449,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 21760
+      "state": "known"
     },
     "compute.rt_core_tflops": {
       "provenance": {
@@ -475,8 +470,7 @@
         ]
       },
       "state": "known",
-      "unit": "tflops",
-      "value": 318
+      "unit": "tflops"
     },
     "compute.tensor_ai_tops": {
       "provenance": {
@@ -497,8 +491,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 3352
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -518,10 +511,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 1792
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -539,10 +531,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -560,8 +551,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7"
+      "state": "known"
     }
   },
   "family": "rtx-5090",
@@ -574,6 +564,7 @@
     "vram_type": "GDDR7"
   },
   "name": "GeForce RTX 5090",
+  "product_names": [],
   "products": [
     "rtx-5090"
   ],

--- a/registry/hardware/rtx-6000-ada-48gb.json
+++ b/registry/hardware/rtx-6000-ada-48gb.json
@@ -27,6 +27,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -211,8 +215,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -244,8 +247,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -331,8 +333,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ada Lovelace"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -346,8 +347,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 18176
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -361,8 +361,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 142
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -376,8 +375,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 568
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -391,10 +389,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 960
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -406,10 +403,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -421,8 +417,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-6000-ada",
@@ -435,6 +430,7 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "RTX 6000 Ada Generation",
+  "product_names": [],
   "products": [
     "rtx-6000-ada"
   ],

--- a/registry/hardware/rtx-a6000-48gb.json
+++ b/registry/hardware/rtx-a6000-48gb.json
@@ -27,6 +27,10 @@
       },
       "state": "unknown"
     },
+    "channel_status": "legacy_partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -214,8 +218,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -247,8 +250,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "legacy_partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -334,8 +336,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Ampere"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -349,8 +350,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10752
+      "state": "known"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -364,8 +364,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 84
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -379,8 +378,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 336
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -394,10 +392,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 768
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -409,10 +406,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 48
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -424,8 +420,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-a6000",
@@ -438,6 +433,7 @@
     "vram_type": "GDDR6 ECC"
   },
   "name": "RTX A6000",
+  "product_names": [],
   "products": [
     "rtx-a6000"
   ],

--- a/registry/hardware/rtx-pro-4000-blackwell-24gb.json
+++ b/registry/hardware/rtx-pro-4000-blackwell-24gb.json
@@ -25,11 +25,16 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
     "architecture": "NVIDIA Blackwell",
     "cuda_cores": 8960,
+    "fp4_tops": 1178,
     "rt_cores": "4th generation",
     "stats": {
       "bf16": {
@@ -212,8 +217,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -263,8 +267,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -350,8 +353,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -365,8 +367,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 8960
+      "state": "known"
     },
     "compute.fp4_tops": {
       "provenance": {
@@ -381,8 +382,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 1178
+      "unit": "tops"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -396,8 +396,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "4th generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -411,8 +410,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "5th generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -426,10 +424,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 672
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -441,10 +438,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -456,8 +452,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-pro-4000-blackwell",
@@ -470,6 +465,7 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "NVIDIA RTX PRO 4000 Blackwell",
+  "product_names": [],
   "products": [
     "rtx-pro-4000-blackwell"
   ],

--- a/registry/hardware/rtx-pro-4500-blackwell-32gb.json
+++ b/registry/hardware/rtx-pro-4500-blackwell-32gb.json
@@ -25,11 +25,16 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
     "architecture": "NVIDIA Blackwell",
     "cuda_cores": 10496,
+    "fp4_tops": 1617,
     "rt_cores": 82,
     "stats": {
       "bf16": {
@@ -260,8 +265,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -311,8 +315,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -398,8 +401,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -413,8 +415,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 10496
+      "state": "known"
     },
     "compute.fp4_tops": {
       "provenance": {
@@ -429,8 +430,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 1617
+      "unit": "tops"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -444,8 +444,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 82
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -459,8 +458,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "5th generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -474,10 +472,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 896
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -489,10 +486,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 32
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -504,8 +500,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-pro-4500-blackwell",
@@ -518,6 +513,7 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "NVIDIA RTX PRO 4500 Blackwell",
+  "product_names": [],
   "products": [
     "rtx-pro-4500-blackwell"
   ],

--- a/registry/hardware/rtx-pro-6000-blackwell-96gb.json
+++ b/registry/hardware/rtx-pro-6000-blackwell-96gb.json
@@ -27,11 +27,16 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
     "architecture": "NVIDIA Blackwell",
     "cuda_cores": 24064,
+    "fp4_tops": 4000,
     "rt_cores": "4th generation",
     "stats": {
       "bf16": {
@@ -214,8 +219,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -247,8 +251,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -334,8 +337,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "NVIDIA Blackwell"
+      "state": "known"
     },
     "compute.cuda_cores": {
       "provenance": {
@@ -349,8 +351,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24064
+      "state": "known"
     },
     "compute.fp4_tops": {
       "provenance": {
@@ -365,8 +366,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 4000
+      "unit": "tops"
     },
     "compute.rt_cores": {
       "provenance": {
@@ -380,8 +380,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "4th generation"
+      "state": "known"
     },
     "compute.tensor_cores": {
       "provenance": {
@@ -395,8 +394,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "5th generation"
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -410,10 +408,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 1792
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -425,10 +422,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -440,8 +436,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR7 ECC"
+      "state": "known"
     }
   },
   "family": "rtx-pro-6000-blackwell",
@@ -454,6 +449,7 @@
     "vram_type": "GDDR7 ECC"
   },
   "name": "RTX PRO 6000 Blackwell",
+  "product_names": [],
   "products": [
     "rtx-pro-6000-blackwell"
   ],

--- a/registry/hardware/rx-7700-xt-12gb.json
+++ b/registry/hardware/rx-7700-xt-12gb.json
@@ -31,6 +31,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 449,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 449,
@@ -288,8 +295,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -357,8 +363,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -427,11 +432,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 449,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -451,11 +452,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -475,8 +472,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD RDNA 3"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -496,8 +492,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 54
+      "state": "known"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -517,8 +512,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 3456
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -538,10 +532,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 432
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -559,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 12
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -580,8 +572,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rx-7700-xt",
@@ -594,6 +585,7 @@
     "vram_type": "GDDR6"
   },
   "name": "AMD Radeon RX 7700 XT",
+  "product_names": [],
   "products": [
     "rx-7700-xt"
   ],

--- a/registry/hardware/rx-7900-xt-20gb.json
+++ b/registry/hardware/rx-7900-xt-20gb.json
@@ -31,6 +31,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 899,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 899,
@@ -310,8 +317,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -355,8 +361,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -425,11 +430,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 899,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -449,11 +450,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -473,8 +470,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD RDNA 3"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -494,8 +490,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 84
+      "state": "known"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -515,8 +510,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 5376
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -536,10 +530,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 800
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -557,10 +550,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 20
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -578,8 +570,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rx-7900-xt",
@@ -592,6 +583,7 @@
     "vram_type": "GDDR6"
   },
   "name": "AMD Radeon RX 7900 XT",
+  "product_names": [],
   "products": [
     "rx-7900-xt"
   ],

--- a/registry/hardware/rx-7900-xtx-24gb.json
+++ b/registry/hardware/rx-7900-xtx-24gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 999,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 999,
@@ -312,8 +319,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -357,8 +363,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -427,11 +432,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 999,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -451,11 +452,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -475,8 +472,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD RDNA 3"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -496,8 +492,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 96
+      "state": "known"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -517,8 +512,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 6144
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -538,10 +532,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 960
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -559,10 +552,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 24
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -580,8 +572,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rx-7900-xtx",
@@ -594,6 +585,7 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon RX 7900 XTX",
+  "product_names": [],
   "products": [
     "rx-7900-xtx"
   ],

--- a/registry/hardware/rx-9070-xt-16gb.json
+++ b/registry/hardware/rx-9070-xt-16gb.json
@@ -33,6 +33,13 @@
       },
       "state": "unknown"
     },
+    "channel_status": "partner_channel",
+    "current_stock": null,
+    "current_street_price": null,
+    "msrp": {
+      "amount": 599,
+      "currency": "USD"
+    },
     "prices": [
       {
         "amount": 599,
@@ -329,8 +336,7 @@
         ]
       },
       "state": "known",
-      "unit": "GPU",
-      "value": 1
+      "unit": "GPU"
     },
     "commercial.availability": {
       "provenance": {
@@ -374,8 +380,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "partner_channel"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -444,11 +449,7 @@
         ]
       },
       "state": "known",
-      "unit": "one_time",
-      "value": {
-        "amount": 599,
-        "currency": "USD"
-      }
+      "unit": "one_time"
     },
     "commercial.prices": {
       "provenance": {
@@ -468,11 +469,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": {
-        "count": 1,
-        "scope": "manufacturer_launch_price"
-      }
+      "state": "known"
     },
     "compute.ai_accelerators": {
       "provenance": {
@@ -492,8 +489,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
     "compute.architecture": {
       "provenance": {
@@ -513,8 +509,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD RDNA 4"
+      "state": "known"
     },
     "compute.compute_units": {
       "provenance": {
@@ -534,8 +529,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 64
+      "state": "known"
     },
     "compute.stream_processors": {
       "provenance": {
@@ -555,8 +549,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 4096
+      "state": "known"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -576,10 +569,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 640
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -597,10 +589,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 16
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -618,8 +609,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "GDDR6"
+      "state": "known"
     }
   },
   "family": "rx-9070-xt",
@@ -632,6 +622,7 @@
     "vram_type": "GDDR6"
   },
   "name": "Radeon RX 9070 XT",
+  "product_names": [],
   "products": [
     "rx-9070-xt"
   ],

--- a/registry/hardware/ryzen-ai-max-plus-395-128gb.json
+++ b/registry/hardware/ryzen-ai-max-plus-395-128gb.json
@@ -21,9 +21,12 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "available"
     },
+    "channel_status": "oem_systems",
+    "current_stock": null,
+    "current_system_price": null,
+    "msrp": null,
     "prices": []
   },
   "compute": {
@@ -196,8 +199,7 @@
         ]
       },
       "state": "known",
-      "unit": "integrated GPU",
-      "value": 1
+      "unit": "integrated GPU"
     },
     "audit.unresolved": {
       "provenance": {
@@ -229,8 +231,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "available"
+      "state": "known"
     },
     "commercial.channel_status": {
       "provenance": {
@@ -244,8 +245,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "oem_systems"
+      "state": "known"
     },
     "commercial.current_stock": {
       "provenance": {
@@ -331,8 +331,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "AMD Zen 5 + RDNA 3.5 + XDNA 2"
+      "state": "known"
     },
     "compute.graphics_compute_units": {
       "provenance": {
@@ -346,8 +345,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": 40
+      "state": "known"
     },
     "compute.graphics_model": {
       "provenance": {
@@ -361,8 +359,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "Radeon 8060S"
+      "state": "known"
     },
     "compute.npu_tops": {
       "provenance": {
@@ -377,8 +374,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 50
+      "unit": "tops"
     },
     "compute.overall_ai_tops": {
       "provenance": {
@@ -393,8 +389,7 @@
         ]
       },
       "state": "known",
-      "unit": "tops",
-      "value": 126
+      "unit": "tops"
     },
     "memory.bandwidth_gb_per_s": {
       "provenance": {
@@ -408,10 +403,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 256
+      "state": "known"
     },
-    "memory.capacity_gb": {
+    "memory.vram_gb": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -423,10 +417,9 @@
           }
         ]
       },
-      "state": "known",
-      "value": 128
+      "state": "known"
     },
-    "memory.type": {
+    "memory.vram_type": {
       "provenance": {
         "captured_at": "2026-08-27T04:55:00Z",
         "sources": [
@@ -438,8 +431,7 @@
           }
         ]
       },
-      "state": "known",
-      "value": "LPDDR5X unified"
+      "state": "known"
     }
   },
   "family": "ryzen-ai-max-plus-395",
@@ -452,6 +444,7 @@
     "vram_type": "LPDDR5X unified"
   },
   "name": "Ryzen AI Max+ 395",
+  "product_names": [],
   "products": [
     "amd-strix-halo-mini-pc"
   ],

--- a/registry/model/agents-a1.json
+++ b/registry/model/agents-a1.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 35.1
+      "state": "known"
     }
   },
   "family": "agents",

--- a/registry/model/deepseek-v4-flash-0731.json
+++ b/registry/model/deepseek-v4-flash-0731.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 304
+      "state": "known"
     }
   },
   "family": "deepseek",

--- a/registry/model/deepseek-v4-flash-dspark.json
+++ b/registry/model/deepseek-v4-flash-dspark.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 291
+      "state": "known"
     }
   },
   "family": "deepseek",

--- a/registry/model/deepseek-v4-flash-spark-200k.json
+++ b/registry/model/deepseek-v4-flash-spark-200k.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 180
+      "state": "known"
     }
   },
   "family": "deepseek",

--- a/registry/model/gemma-4-e2b-it.json
+++ b/registry/model/gemma-4-e2b-it.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 5.1
+      "state": "known"
     }
   },
   "family": "gemma",

--- a/registry/model/gemma-4-e4b-it.json
+++ b/registry/model/gemma-4-e4b-it.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 8
+      "state": "known"
     }
   },
   "family": "gemma",

--- a/registry/model/glm-5-2-vision.json
+++ b/registry/model/glm-5-2-vision.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 753.8
+      "state": "known"
     }
   },
   "family": "glm",

--- a/registry/model/hy3.json
+++ b/registry/model/hy3.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 299
+      "state": "known"
     }
   },
   "family": "hy3",

--- a/registry/model/inkling-small.json
+++ b/registry/model/inkling-small.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 266
+      "state": "known"
     }
   },
   "family": "inkling",

--- a/registry/model/kimi-k2-6.json
+++ b/registry/model/kimi-k2-6.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 520
+      "state": "known"
     }
   },
   "family": "kimi",

--- a/registry/model/laguna-s-2-1-q4km.json
+++ b/registry/model/laguna-s-2-1-q4km.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 118
+      "state": "known"
     }
   },
   "family": "laguna",

--- a/registry/model/laguna-s-2-1.json
+++ b/registry/model/laguna-s-2-1.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 118
+      "state": "known"
     }
   },
   "family": "laguna",

--- a/registry/model/laguna-xs-2-1-q4km.json
+++ b/registry/model/laguna-xs-2-1-q4km.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 33.4
+      "state": "known"
     }
   },
   "family": "laguna",

--- a/registry/model/laguna-xs-2-1.json
+++ b/registry/model/laguna-xs-2-1.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 33.4
+      "state": "known"
     }
   },
   "family": "laguna",

--- a/registry/model/mimo-v2-flash.json
+++ b/registry/model/mimo-v2-flash.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 310
+      "state": "known"
     }
   },
   "family": "mimo",

--- a/registry/model/nemotron-3-ultra.json
+++ b/registry/model/nemotron-3-ultra.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 550
+      "state": "known"
     }
   },
   "family": "nemotron",

--- a/registry/model/nex-n2-mini.json
+++ b/registry/model/nex-n2-mini.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 35.1
+      "state": "known"
     }
   },
   "family": "nex",

--- a/registry/model/nex-n2-pro.json
+++ b/registry/model/nex-n2-pro.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 397
+      "state": "known"
     }
   },
   "family": "nex",

--- a/registry/model/step-3-7-flash.json
+++ b/registry/model/step-3-7-flash.json
@@ -42,8 +42,7 @@
         ]
       },
       "reason": "source-parameter-metadata",
-      "state": "known",
-      "value": 201
+      "state": "known"
     }
   },
   "family": "step",

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-rtxpro6000-vllm-tp4.json
@@ -26,7 +26,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/gemma-4-31b-it-bf16-rtxpro6000-vllm-tp2.json
+++ b/registry/recipe/gemma-4-31b-it-bf16-rtxpro6000-vllm-tp2.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/gemma-4-31b-it-nvfp4-rtxpro6000-vllm-tp2.json
+++ b/registry/recipe/gemma-4-31b-it-nvfp4-rtxpro6000-vllm-tp2.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/glm-5.2-nvfp4-b200-vllm-tp8-mtp5.json
+++ b/registry/recipe/glm-5.2-nvfp4-b200-vllm-tp8-mtp5.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/hy3-fp8-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/hy3-fp8-rtxpro6000-vllm-tp4.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/kimi-k2.6-nvfp4-rtxpro6000-sglang-tp4.json
+++ b/registry/recipe/kimi-k2.6-nvfp4-rtxpro6000-sglang-tp4.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/lfm25-8b-a1b-native-rtxpro6000-vllm-tp1.json
+++ b/registry/recipe/lfm25-8b-a1b-native-rtxpro6000-vllm-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/ornith15-35b-a3b-iq2-xxs-rtx2000ada-llamacpp-tp1.json
+++ b/registry/recipe/ornith15-35b-a3b-iq2-xxs-rtx2000ada-llamacpp-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/ornith15-35b-a3b-mixed-iq3-rtx4000ada-llamacpp-tp1.json
+++ b/registry/recipe/ornith15-35b-a3b-mixed-iq3-rtx4000ada-llamacpp-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/qwen3.6-35b-a3b-nvfp4-rtxpro6000-vllm-tp2-mtp3.json
+++ b/registry/recipe/qwen3.6-35b-a3b-nvfp4-rtxpro6000-vllm-tp2-mtp3.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/qwen3.6-35b-a3b-nvfp4-rtxpro6000-vllm-tp2-mtp4.json
+++ b/registry/recipe/qwen3.6-35b-a3b-nvfp4-rtxpro6000-vllm-tp2-mtp4.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/qwen36-27b-autoround-int4-rtxpro6000-vllm-tp1.json
+++ b/registry/recipe/qwen36-27b-autoround-int4-rtxpro6000-vllm-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/qwen36-27b-autoround-int8-rtxpro6000-vllm-tp1.json
+++ b/registry/recipe/qwen36-27b-autoround-int8-rtxpro6000-vllm-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/qwen36-35b-a3b-q4-k-m-rtxpro6000-llama-cpp-tp1.json
+++ b/registry/recipe/qwen36-35b-a3b-q4-k-m-rtxpro6000-llama-cpp-tp1.json
@@ -82,7 +82,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/step-37-flash-fp8-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/step-37-flash-fp8-rtxpro6000-vllm-tp4.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/recipe/step-37-flash-nvfp4-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/step-37-flash-nvfp4-rtxpro6000-vllm-tp4.json
@@ -68,7 +68,7 @@
       "reason": "not-observed",
       "state": "unknown"
     },
-    "speed_sweeps_ids": {
+    "speed_sweep_ids": {
       "provenance": {
         "captured_at": "2026-08-27T06:04:13.773Z",
         "sources": [

--- a/registry/schema/common.schema.json
+++ b/registry/schema/common.schema.json
@@ -81,7 +81,6 @@
         "provenance"
       ],
       "properties": {
-        "value": {},
         "state": {
           "enum": [
             "known",
@@ -141,23 +140,6 @@
           "if": {
             "properties": {
               "state": {
-                "const": "known"
-              }
-            },
-            "required": [
-              "state"
-            ]
-          },
-          "then": {
-            "required": [
-              "value"
-            ]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "state": {
                 "enum": [
                   "unknown",
                   "unavailable",
@@ -176,7 +158,8 @@
           }
         }
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Per-field provenance and knowledge state. The field value itself lives once, at the record path the facts key names; facts never carry a duplicate value."
     },
     "facts": {
       "type": "object",

--- a/registry/schema/hardware.schema.json
+++ b/registry/schema/hardware.schema.json
@@ -153,7 +153,81 @@
       ],
       "properties": {
         "availability": {
-          "$ref": "common.schema.json#/$defs/fact"
+          "type": "object",
+          "required": [
+            "state",
+            "provenance"
+          ],
+          "properties": {
+            "state": {
+              "enum": [
+                "available",
+                "unavailable",
+                "unknown",
+                "not_applicable"
+              ]
+            },
+            "reason": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "detail"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "detail": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "note": {
+              "type": "string",
+              "minLength": 1
+            },
+            "provenance": {
+              "$ref": "common.schema.json#/$defs/provenance"
+            },
+            "scope": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "state": {
+                    "enum": [
+                      "unknown",
+                      "not_applicable"
+                    ]
+                  }
+                },
+                "required": [
+                  "state"
+                ]
+              },
+              "then": {
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          ]
         },
         "prices": {
           "type": "array",
@@ -212,6 +286,103 @@
             },
             "additionalProperties": false
           }
+        },
+        "msrp": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "amount": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "additionalProperties": false
+        },
+        "current_street_price": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "amount": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "additionalProperties": false
+        },
+        "exact_configuration_price": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "amount": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "additionalProperties": false
+        },
+        "channel_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "current_stock": {
+          "type": [
+            "string",
+            "boolean",
+            "null"
+          ]
+        },
+        "current_system_price": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "amount": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -323,6 +494,13 @@
     },
     "facts": {
       "$ref": "common.schema.json#/$defs/facts"
+    },
+    "product_names": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Marketed product names this chip/configuration ships in (e.g. MacBook Pro 16-inch); products holds price-record product ids."
     }
   },
   "$defs": {

--- a/registry/schema/types.ts
+++ b/registry/schema/types.ts
@@ -4,8 +4,10 @@
  * Regenerate with: npm run gen:types
  */
 
+/**
+ * Per-field provenance and knowledge state. The field value itself lives once, at the record path the facts key names; facts never carry a duplicate value.
+ */
 export type Fact = {
-  value?: unknown
   state: "known" | "unknown" | "unavailable" | "not_applicable"
   reason?:
     | string
@@ -118,7 +120,18 @@ export interface Hardware {
     [k: string]: unknown
   }[]
   commercial?: {
-    availability: Fact
+    availability: {
+      state: "available" | "unavailable" | "unknown" | "not_applicable"
+      reason?:
+        | string
+        | {
+            code: string
+            detail: string
+          }
+      note?: string
+      provenance: Provenance
+      scope?: string
+    }
     prices: {
       amount: number
       currency: string
@@ -131,6 +144,24 @@ export interface Hardware {
       source: Source
       captured_at: string
     }[]
+    msrp?: {
+      amount: number
+      currency: string
+    } | null
+    current_street_price?: {
+      amount: number
+      currency: string
+    } | null
+    exact_configuration_price?: {
+      amount: number
+      currency: string
+    } | null
+    channel_status?: string | null
+    current_stock?: string | boolean | null
+    current_system_price?: {
+      amount: number
+      currency: string
+    } | null
   }
   compute?: {
     stats: {
@@ -140,6 +171,10 @@ export interface Hardware {
   }
   provenance?: Provenance
   facts?: Facts
+  /**
+   * Marketed product names this chip/configuration ships in (e.g. MacBook Pro 16-inch); products holds price-record product ids.
+   */
+  product_names?: string[]
   [k: string]: unknown
 }
 export interface Provenance {

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -91,8 +91,16 @@ def validate_facts(record, errors):
         structured_reason = isinstance(reason, dict) and isinstance(reason.get("code"), str) and bool(reason.get("code")) and isinstance(reason.get("detail"), str) and bool(reason.get("detail"))
         if fact.get("state") != "known" and not ((isinstance(reason, str) and bool(reason)) or structured_reason):
             errors.append(f"{label}: missing reason")
-        if fact.get("state") == "known" and "value" not in fact:
-            errors.append(f"{label}: known fact has no value")
+        if "value" in fact:
+            errors.append(f"{label}: facts must not duplicate the record value")
+        if not path.startswith("audit."):
+            target = record
+            for part in path.split("."):
+                if isinstance(target, dict) and part in target:
+                    target = target[part]
+                else:
+                    errors.append(f"{label}: fact path does not resolve to a record field")
+                    break
         validate_provenance(fact.get("provenance"), label, errors)
 
 
@@ -273,9 +281,9 @@ def validate(root):
             validate_facts(record, errors)
         availability = (record.get("commercial") or {}).get("availability")
         if availability is not None:
-            if not isinstance(availability, dict) or availability.get("state") not in ("known", "unknown", "unavailable", "not_applicable"):
+            if not isinstance(availability, dict) or availability.get("state") not in ("available", "unavailable", "unknown", "not_applicable"):
                 errors.append(f"{record.get('id')}: commercial availability has invalid state")
-            elif availability.get("state") != "known" and not availability.get("reason"):
+            elif availability.get("state") in ("unknown", "not_applicable") and not availability.get("reason"):
                 errors.append(f"{record.get('id')}: commercial availability requires a reason when not known")
 
     for record in data["model-instance"].values():


### PR DESCRIPTION
Ends the double-bookkeeping between record fields and the `facts` map. The audit showed facts were four things at once: true mirrors (452 values), **data that existed only in facts under different names** (448 paths — including every MSRP the earlier audit reported as "missing"), summaries of complex fields, and explicit unknowns.

- Mirrors lose their duplicate `value`; the record field is canonical.
- Facts-only data promoted into records: `commercial.msrp` / `channel_status` / `current_street_price` / `current_stock` / `exact_configuration_price` / `current_system_price`, `product_names` (marketed names; `products` keeps price-product ids), vendor compute figures (`fp4_tops` …). Unknown-state fields materialize as explicit nulls; all 100 hardware records share one key set again.
- Availability contradiction resolved: facts knew `available`/`unavailable` while records said not-captured — the richer vocabulary wins, `availability` gets its own schema, and the 60 stale duplicates are gone.
- New enforcement (schema + validator): facts must not carry `value`, and every fact key must resolve to a real record path (`audit.*` meta-notes excepted). Stale `speed_sweeps_ids` fact keys from the rename fixed.

`make check` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)