### PR TITLE
Models page: sort by HF monthly downloads

### DIFF
--- a/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/edited-files.log
+++ b/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/edited-files.log
@@ -1,2 +1,3 @@
 1788174978:/Users/sero/local-registry/local-ai-registry/Makefile:root
 1788175192:/Users/sero/local-registry/local-ai-registry/app/page.tsx:app
+1788179834:/Users/sero/local-registry/local-ai-registry/app/page.tsx:app

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,8 @@ typecheck:
 
 build:
 	npm run build
+
+## Refresh Hugging Face download counts (models-page sort order).
+downloads:
+	python3 scripts/fetch_hf_downloads.py
+	python3 scripts/format_registry.py

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -474,6 +474,7 @@ export default async function Home({ searchParams }: PageProps) {
                     <span><strong>{model.family}</strong><small>family</small></span>
                     <span><strong>{model.architecture ?? "Unknown"}</strong><small>architecture</small></span>
                     <span><strong>{model.params ?? "—"}</strong><small>parameters</small></span>
+                    <span><strong>{model.downloads?.last_30d != null ? model.downloads.last_30d.toLocaleString("en-US") : "—"}</strong><small>HF downloads / 30d</small></span>
                     <TaxonomyTags state={viewState} tags={tags} />
                     <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
                   </article>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -384,12 +384,19 @@ export function queryCompatibility(
 }
 
 export function listModels(filters: Record<string, string>, pagination: Pagination) {
-  const all = [...dataset().models.values()].filter(
-    (model) =>
-      contains(model, filters.q) &&
-      equals(model.family, filters.family) &&
-      (filters.architecture === "unknown" ? model.architecture === null : equals(model.architecture, filters.architecture)),
-  )
+  const all = [...dataset().models.values()]
+    .filter(
+      (model) =>
+        contains(model, filters.q) &&
+        equals(model.family, filters.family) &&
+        (filters.architecture === "unknown" ? model.architecture === null : equals(model.architecture, filters.architecture)),
+    )
+    .sort(
+      (left, right) =>
+        (right.downloads?.last_30d ?? -1) - (left.downloads?.last_30d ?? -1) ||
+        left.name.localeCompare(right.name, undefined, { numeric: true }) ||
+        left.id.localeCompare(right.id),
+    )
   return { data: all.slice(pagination.offset, pagination.offset + pagination.limit), total: all.length }
 }
 

--- a/registry/model/acereason-nemotron-1-1-7b.json
+++ b/registry/model/acereason-nemotron-1-1-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 154965,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 555,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/agents-a1-4b.json
+++ b/registry/model/agents-a1-4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 162628,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 144797,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/agents-a1.json
+++ b/registry/model/agents-a1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 70563,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 19679,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/bartowski-qwen2-72b-instruct-gguf-qwen2-72b-instruct-q4-k-m-gguf.json
+++ b/registry/model/bartowski-qwen2-72b-instruct-gguf-qwen2-72b-instruct-q4-k-m-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 28195,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 877,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/bonsai-27b.json
+++ b/registry/model/bonsai-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/btl-4.json
+++ b/registry/model/btl-4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 93024,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 93024,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/carnice-9b.json
+++ b/registry/model/carnice-9b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 23247,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 25,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepreinforce-ai-ornith-1-0-35b-gguf-ornith-1-0-35b-q4-k-m-gguf.json
+++ b/registry/model/deepreinforce-ai-ornith-1-0-35b-gguf-ornith-1-0-35b-q4-k-m-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 7100018,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3162990,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-coder-v2-lite-instruct-fp8.json
+++ b/registry/model/deepseek-coder-v2-lite-instruct-fp8.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1258649,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 142736,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-coder-v2-lite-instruct.json
+++ b/registry/model/deepseek-coder-v2-lite-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9909101,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 689885,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-r1-0528-qwen3-8b.json
+++ b/registry/model/deepseek-r1-0528-qwen3-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1417276,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 122929,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-r1-distill-qwen-14b.json
+++ b/registry/model/deepseek-r1-distill-qwen-14b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 151571,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 886,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-r1-distill-qwen-32b.json
+++ b/registry/model/deepseek-r1-distill-qwen-32b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 27220821,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 584385,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-r1-distill-qwen-7b.json
+++ b/registry/model/deepseek-r1-distill-qwen-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1766009,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 21191,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-v4-flash-0731.json
+++ b/registry/model/deepseek-v4-flash-0731.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 4710705,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4561861,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-v4-flash-2bit-dq.json
+++ b/registry/model/deepseek-v4-flash-2bit-dq.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 102724,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 19160,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-v4-flash-dspark.json
+++ b/registry/model/deepseek-v4-flash-dspark.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 11014089,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1704533,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-v4-flash-spark-200k.json
+++ b/registry/model/deepseek-v4-flash-spark-200k.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 22021,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3345,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek-v4-flash.json
+++ b/registry/model/deepseek-v4-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 11014089,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1704533,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/deepseek.json
+++ b/registry/model/deepseek.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/diffusiongemma-26b-a4b-it.json
+++ b/registry/model/diffusiongemma-26b-a4b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 4975389,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1339787,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "gemma",
   "huggingface": {

--- a/registry/model/diffusiongemma-26b-a4b.json
+++ b/registry/model/diffusiongemma-26b-a4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/gemma-3-12b-pt.json
+++ b/registry/model/gemma-3-12b-pt.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 22458457,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 921684,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-3-1b-pt.json
+++ b/registry/model/gemma-3-1b-pt.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 49275026,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3374554,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-3-4b-it-bf16.json
+++ b/registry/model/gemma-3-4b-it-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 10170,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 451,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-3-4b-pt.json
+++ b/registry/model/gemma-3-4b-pt.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 25193447,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1447256,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-3n-e4b-it-text-gguf.json
+++ b/registry/model/gemma-3n-e4b-it-text-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 348872,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 7584,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-3n-e4b.json
+++ b/registry/model/gemma-3n-e4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1378996,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 23931,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b-coder-fable5-composer2-5-v1-gguf.json
+++ b/registry/model/gemma-4-12b-coder-fable5-composer2-5-v1-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1436702,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 483381,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b-coder-fable5-composer2-5-v1.json
+++ b/registry/model/gemma-4-12b-coder-fable5-composer2-5-v1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 25230,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3615,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b-it-qat-q4-0-unquantized.json
+++ b/registry/model/gemma-4-12b-it-qat-q4-0-unquantized.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1030835,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 250984,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b-it.json
+++ b/registry/model/gemma-4-12b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 9548996,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3329756,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b-q4km.json
+++ b/registry/model/gemma-4-12b-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-12b.json
+++ b/registry/model/gemma-4-12b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 768740,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 97097,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-19b.json
+++ b/registry/model/gemma-4-19b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9199,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 267,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "gemma",
   "huggingface": {

--- a/registry/model/gemma-4-26b-a4b-it-qat-q4-0-unquantized.json
+++ b/registry/model/gemma-4-26b-a4b-it-qat-q4-0-unquantized.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 942087,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 509277,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-26b-a4b-it.json
+++ b/registry/model/gemma-4-26b-a4b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 54054728,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 8137724,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-26b-a4b.json
+++ b/registry/model/gemma-4-26b-a4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 2103895,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 86510,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "gemma",
   "huggingface": {

--- a/registry/model/gemma-4-31b-it-qat-q4-0-unquantized.json
+++ b/registry/model/gemma-4-31b-it-qat-q4-0-unquantized.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1220098,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 603688,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-31b-it.json
+++ b/registry/model/gemma-4-31b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 52848922,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 8317909,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-31b-v2-mlx-4bit.json
+++ b/registry/model/gemma-4-31b-v2-mlx-4bit.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 377,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 32,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-31b-v2.json
+++ b/registry/model/gemma-4-31b-v2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-31b.json
+++ b/registry/model/gemma-4-31b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3241337,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 713290,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-e2b-it.json
+++ b/registry/model/gemma-4-e2b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 4175691,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 566649,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-e2b.json
+++ b/registry/model/gemma-4-e2b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 16596640,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3372443,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-e4b-it-qat-q4-0-unquantized.json
+++ b/registry/model/gemma-4-e4b-it-qat-q4-0-unquantized.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1000819,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 560381,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-e4b-it.json
+++ b/registry/model/gemma-4-e4b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 4988139,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 564527,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemma-4-e4b.json
+++ b/registry/model/gemma-4-e4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemmable-4-12b-mtp-gguf.json
+++ b/registry/model/gemmable-4-12b-mtp-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1046230,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 438110,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gemopus-4-26b-a4b-it-gguf.json
+++ b/registry/model/gemopus-4-26b-a4b-it-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 58040,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1096,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "llama",
   "huggingface": {

--- a/registry/model/gemopus-4-26b-a4b-it.json
+++ b/registry/model/gemopus-4-26b-a4b-it.json
@@ -1,6 +1,12 @@
 {
   "active_params": 4,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 4709,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 930,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "gemma",
   "huggingface": {

--- a/registry/model/glm-4-5-air.json
+++ b/registry/model/glm-4-5-air.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 4604459,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 115734,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-4-6v-flash.json
+++ b/registry/model/glm-4-6v-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 493648,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 53172,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-4-7-flash.json
+++ b/registry/model/glm-4-7-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 12418524,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1939208,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-4-9b-chat.json
+++ b/registry/model/glm-4-9b-chat.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1847,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 95,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-1-nvfp4.json
+++ b/registry/model/glm-5-1-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 160291,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2518,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-1.json
+++ b/registry/model/glm-5-1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 28112,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1349,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-2-mxfp8-nvfp4-nf3-hybrid.json
+++ b/registry/model/glm-5-2-mxfp8-nvfp4-nf3-hybrid.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 5684,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 445,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-2-nvfp4.json
+++ b/registry/model/glm-5-2-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 3074478,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1165743,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-2-vision.json
+++ b/registry/model/glm-5-2-vision.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 376,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 129,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-2.json
+++ b/registry/model/glm-5-2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 3818948,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1552546,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-5-3-flash.json
+++ b/registry/model/glm-5-3-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 379271,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 379271,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-z1-32b-0414.json
+++ b/registry/model/glm-z1-32b-0414.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 84075,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 22495,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/glm-z1-rumination-32b-0414.json
+++ b/registry/model/glm-z1-rumination-32b-0414.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 12546,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 446,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/godoter-27b.json
+++ b/registry/model/godoter-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3944,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1173,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gpt-oss-120b.json
+++ b/registry/model/gpt-oss-120b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 122493,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4886,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/gpt-oss-20b.json
+++ b/registry/model/gpt-oss-20b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 7384586,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 318803,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/granite-4-1-8b.json
+++ b/registry/model/granite-4-1-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 67773,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 13616,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/granite-4-2-8b.json
+++ b/registry/model/granite-4-2-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 69729,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 69729,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/grug-12b.json
+++ b/registry/model/grug-12b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3728,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 163,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/harmonic-hermes-9b-gguf.json
+++ b/registry/model/harmonic-hermes-9b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 19852,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 667,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/hcompany-holo-3-1-35b-a3b-gguf-q4-k-m-gguf.json
+++ b/registry/model/hcompany-holo-3-1-35b-a3b-gguf-q4-k-m-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 613661,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 170995,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/holo-3-1-35b-a3b.json
+++ b/registry/model/holo-3-1-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/huihui-qwen3-6-27b-abliterated.json
+++ b/registry/model/huihui-qwen3-6-27b-abliterated.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 71715,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 14928,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/huihui-qwen3-8-27b-abliterated.json
+++ b/registry/model/huihui-qwen3-8-27b-abliterated.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 51085,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 51085,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/huihui-qwythos-9b-claude-mythos-5-1m-abliterated.json
+++ b/registry/model/huihui-qwythos-9b-claude-mythos-5-1m-abliterated.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 19961,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2764,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/hunyuan-mt-7b.json
+++ b/registry/model/hunyuan-mt-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 138494,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3958,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/hy-mt2-7b.json
+++ b/registry/model/hy-mt2-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 86719,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 12052,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/hy3.json
+++ b/registry/model/hy3.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 34659,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 11680,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/inkling-small.json
+++ b/registry/model/inkling-small.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 174436,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 167800,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/internlm3-8b-instruct.json
+++ b/registry/model/internlm3-8b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 20103,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 907,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/internvl3-14b-instruct.json
+++ b/registry/model/internvl3-14b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 4838258,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 15448,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/internvl3-38b-instruct.json
+++ b/registry/model/internvl3-38b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1336889,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2168,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/internvl3-8b-instruct.json
+++ b/registry/model/internvl3-8b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3110392,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 97100,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/internvl3-8b.json
+++ b/registry/model/internvl3-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 31146,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 973,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/kat-coder-v2-5-dev.json
+++ b/registry/model/kat-coder-v2-5-dev.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 554,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 389,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/kimi-k2-5.json
+++ b/registry/model/kimi-k2-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/kimi-k2-6.json
+++ b/registry/model/kimi-k2-6.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 1470,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 40,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/kimi-linear-48b-a3b-instruct.json
+++ b/registry/model/kimi-linear-48b-a3b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1124827,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 180262,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/laguna-s-2-1-fp8.json
+++ b/registry/model/laguna-s-2-1-fp8.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 8543,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4264,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/laguna-s-2-1-nvfp4.json
+++ b/registry/model/laguna-s-2-1-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 718696,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 412399,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/laguna-s-2-1-q4km.json
+++ b/registry/model/laguna-s-2-1-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 674738,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 563471,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/laguna-s-2-1.json
+++ b/registry/model/laguna-s-2-1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 674738,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 563471,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/laguna-xs-2-1-q4km.json
+++ b/registry/model/laguna-xs-2-1-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 249169,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 196493,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/laguna-xs-2-1.json
+++ b/registry/model/laguna-xs-2-1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 249169,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 196493,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-24b-a2b.json
+++ b/registry/model/lfm2-24b-a2b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 2,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 158945,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 11205,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "llama",
   "huggingface": {

--- a/registry/model/lfm2-5-1-2b-base.json
+++ b/registry/model/lfm2-5-1-2b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 2486870,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 391220,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-5-1-2b-instruct.json
+++ b/registry/model/lfm2-5-1-2b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1266096,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 332839,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-5-1-2b-thinking.json
+++ b/registry/model/lfm2-5-1-2b-thinking.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 222094,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 15099,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-5-2-6b.json
+++ b/registry/model/lfm2-5-2-6b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 200631,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 198253,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-5-8b-a1b-base.json
+++ b/registry/model/lfm2-5-8b-a1b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 12910,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1735,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/lfm2-5-8b-a1b.json
+++ b/registry/model/lfm2-5-8b-a1b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 1,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 501923,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 99989,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "lfm",
   "huggingface": {

--- a/registry/model/lfm2-8b-a1b.json
+++ b/registry/model/lfm2-8b-a1b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 1,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 417904,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 31054,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/ling-2-6-flash.json
+++ b/registry/model/ling-2-6-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 25329,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2415,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ling-3-0-flash.json
+++ b/registry/model/ling-3-0-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 19902,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 19881,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ling-3-0-tiny.json
+++ b/registry/model/ling-3-0-tiny.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 2544,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2544,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-2-7b-hf.json
+++ b/registry/model/llama-2-7b-hf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 33799152,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 799192,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-1-70b-instruct.json
+++ b/registry/model/llama-3-1-70b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 326334,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2051,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-1-70b.json
+++ b/registry/model/llama-3-1-70b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 601954,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 20770,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-1-8b-instruct.json
+++ b/registry/model/llama-3-1-8b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 2419210,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 33589,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-1-8b.json
+++ b/registry/model/llama-3-1-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 180778261,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5861628,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-1-nemotron-70b-q4km.json
+++ b/registry/model/llama-3-1-nemotron-70b-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-2-1b-instruct.json
+++ b/registry/model/llama-3-2-1b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 98737087,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6580703,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-2-3b-instruct.json
+++ b/registry/model/llama-3-2-3b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 47610611,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1064703,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/llama-3-3-70b-instruct-q4km.json
+++ b/registry/model/llama-3-3-70b-instruct-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mellum2-12b-a2-5b-instruct.json
+++ b/registry/model/mellum2-12b-a2-5b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 106972,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 92405,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "llama",
   "huggingface": {

--- a/registry/model/mellum2-12b-a2-5b-thinking.json
+++ b/registry/model/mellum2-12b-a2-5b-thinking.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 25819,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3735,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "llama",
   "huggingface": {

--- a/registry/model/meta-llama-3-8b-instruct.json
+++ b/registry/model/meta-llama-3-8b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 47491248,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1628648,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mimo-v2-5.json
+++ b/registry/model/mimo-v2-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1248028,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 379054,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mimo-v2-flash.json
+++ b/registry/model/mimo-v2-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 42033,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 12896,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/minicpm5-1b-gguf.json
+++ b/registry/model/minicpm5-1b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 207115,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 39693,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/minicpm5-1b.json
+++ b/registry/model/minicpm5-1b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 22728,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1192,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/minimax-m2-5.json
+++ b/registry/model/minimax-m2-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9524,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 93,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/minimax-m2-7.json
+++ b/registry/model/minimax-m2-7.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 6403830,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1142168,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/minimax-m3.json
+++ b/registry/model/minimax-m3.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 580652,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 194488,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ministral-3-14b-reasoning-2512.json
+++ b/registry/model/ministral-3-14b-reasoning-2512.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 67188,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 22908,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ministral-3-3b-base-2512.json
+++ b/registry/model/ministral-3-3b-base-2512.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3776247,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 348861,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mistral-nemo-base-2407.json
+++ b/registry/model/mistral-nemo-base-2407.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 10138686,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 408998,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mistral-small-24b-base-2501.json
+++ b/registry/model/mistral-small-24b-base-2501.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 28717,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 619,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mistral-small-3-1-24b-base-2503.json
+++ b/registry/model/mistral-small-3-1-24b-base-2503.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 5199059,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 163938,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mistral-small-3-1-24b-instruct-2503.json
+++ b/registry/model/mistral-small-3-1-24b-instruct-2503.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 831886,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2900,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/mistral-small-3-2-24b-instruct-2506.json
+++ b/registry/model/mistral-small-3-2-24b-instruct-2506.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 776173,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 37848,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/muse-glimmer-30b.json
+++ b/registry/model/muse-glimmer-30b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 600273,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 600273,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nemotron-3-nano-30b-a3b.json
+++ b/registry/model/nemotron-3-nano-30b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 11641,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 594,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "nemotron",
   "huggingface": {

--- a/registry/model/nemotron-3-nano-omni-30b-a3b-reasoning-bf16.json
+++ b/registry/model/nemotron-3-nano-omni-30b-a3b-reasoning-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 486442,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 63990,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/nemotron-3-ultra.json
+++ b/registry/model/nemotron-3-ultra.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 1167105,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 415981,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nemotron-cascade-14b-thinking.json
+++ b/registry/model/nemotron-cascade-14b-thinking.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 28565,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2357,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nemotron-cascade-2-30b-a3b.json
+++ b/registry/model/nemotron-cascade-2-30b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/nemotron-cascade-8b.json
+++ b/registry/model/nemotron-cascade-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 12587,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 962,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nex-n2-mini.json
+++ b/registry/model/nex-n2-mini.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 22862,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1674,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nex-n2-pro.json
+++ b/registry/model/nex-n2-pro.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 11185,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 941,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/north-mini-code-1-0.json
+++ b/registry/model/north-mini-code-1-0.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 72463,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 21544,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-bf16.json
+++ b/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 199555,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 199555,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-gguf.json
+++ b/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 27052,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 27052,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-nvfp4.json
+++ b/registry/model/nvidia-nemotron-3-5-lightning-30b-a3b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 946320,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 946320,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "opt",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-5.json
+++ b/registry/model/nvidia-nemotron-3-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-3-nano-30b-a3b-bf16.json
+++ b/registry/model/nvidia-nemotron-3-nano-30b-a3b-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9051209,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 863689,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "nemotron",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-nano-4b-bf16.json
+++ b/registry/model/nvidia-nemotron-3-nano-4b-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 413988,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 51002,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-3-nano-4b-fp8.json
+++ b/registry/model/nvidia-nemotron-3-nano-4b-fp8.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 89535,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 10964,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-3-super-120b-a12b-bf16.json
+++ b/registry/model/nvidia-nemotron-3-super-120b-a12b-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": 12,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 5274,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 882,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-super-120b-a12b-nvfp4.json
+++ b/registry/model/nvidia-nemotron-3-super-120b-a12b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": 12,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9356451,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1101200,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "opt",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-3-super-120b-a12b.json
+++ b/registry/model/nvidia-nemotron-3-super-120b-a12b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 12,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-3-ultra-550b-a55b.json
+++ b/registry/model/nvidia-nemotron-3-ultra-550b-a55b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 55.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1673,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 241,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "nemotron",
   "huggingface": {

--- a/registry/model/nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4.json
+++ b/registry/model/nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1130,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 104,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-nano-12b-v2-base.json
+++ b/registry/model/nvidia-nemotron-nano-12b-v2-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 4027721,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 417919,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/nvidia-nemotron-nano-9b-v2.json
+++ b/registry/model/nvidia-nemotron-nano-9b-v2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 3486025,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 380184,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/olmo-3-32b-think-dpo.json
+++ b/registry/model/olmo-3-32b-think-dpo.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 68841,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 10612,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/openreasoning-nemotron-32b.json
+++ b/registry/model/openreasoning-nemotron-32b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 2558,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 249,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/openreasoning-nemotron-7b.json
+++ b/registry/model/openreasoning-nemotron-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 2739,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 370,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-35b-aeon-ultimate-uncensored-bf16.json
+++ b/registry/model/ornith-1-0-35b-aeon-ultimate-uncensored-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 58046,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4041,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-35b-gguf.json
+++ b/registry/model/ornith-1-0-35b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 7100018,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3162990,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-35b.json
+++ b/registry/model/ornith-1-0-35b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 6003553,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3045441,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-397b.json
+++ b/registry/model/ornith-1-0-397b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 707071,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 247923,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-9b-gguf.json
+++ b/registry/model/ornith-1-0-9b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 9460434,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4410015,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-0-9b.json
+++ b/registry/model/ornith-1-0-9b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 4125350,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1805743,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-5-35b-a3b-gguf.json
+++ b/registry/model/ornith-1-5-35b-a3b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 2237578,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2237578,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "unknown",
   "huggingface": {

--- a/registry/model/ornith-1-5-35b-a3b-mtp.json
+++ b/registry/model/ornith-1-5-35b-a3b-mtp.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 4782,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4782,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/ornith-1-5-35b-a3b-nvfp4.json
+++ b/registry/model/ornith-1-5-35b-a3b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 472618,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 472618,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/ornith-1-5-35b-a3b.json
+++ b/registry/model/ornith-1-5-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 172695,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 172695,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "ornith",
   "huggingface": {

--- a/registry/model/ornith-1-5-9b-gguf.json
+++ b/registry/model/ornith-1-5-9b-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 2425069,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2425069,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornith-1-5-9b.json
+++ b/registry/model/ornith-1-5-9b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 217583,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 217583,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornstein-3-6-27b.json
+++ b/registry/model/ornstein-3-6-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 5277,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 134,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornstein-hermes-3-6-27b.json
+++ b/registry/model/ornstein-hermes-3-6-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 637,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 97,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornstein3-6-27b-mtp-nsc-ace-saber.json
+++ b/registry/model/ornstein3-6-27b-mtp-nsc-ace-saber.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 7898,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 233,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ornstein3-6-35b-a3b.json
+++ b/registry/model/ornstein3-6-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 11676,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2523,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/phi-4-mini-instruct.json
+++ b/registry/model/phi-4-mini-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 314838,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 38422,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/phi-4-mini-reasoning.json
+++ b/registry/model/phi-4-mini-reasoning.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 161512,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6662,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/phi-4-reasoning-plus.json
+++ b/registry/model/phi-4-reasoning-plus.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 139512,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 8077,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/phi-4.json
+++ b/registry/model/phi-4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 13892820,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 633005,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/quest-30b-rl.json
+++ b/registry/model/quest-30b-rl.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 262,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 41,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwable-3-6-35b.json
+++ b/registry/model/qwable-3-6-35b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 16803,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 604,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen-3-14b-instruct-gguf.json
+++ b/registry/model/qwen-3-14b-instruct-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 80589,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 19979,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen-agentworld-35b-a3b.json
+++ b/registry/model/qwen-agentworld-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1309355,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 421585,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen-qwen3-235b-a22b.json
+++ b/registry/model/qwen-qwen3-235b-a22b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 22.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 473771,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 17346,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen-qwen3-8-27b.json
+++ b/registry/model/qwen-qwen3-8-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 9059937,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 9059937,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-0-5b.json
+++ b/registry/model/qwen2-5-0-5b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 62499308,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6013414,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-14b.json
+++ b/registry/model/qwen2-5-14b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 47194756,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2733990,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-32b.json
+++ b/registry/model/qwen2-5-32b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 250470,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 609,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-72b-instruct-q4km.json
+++ b/registry/model/qwen2-5-72b-instruct-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-72b.json
+++ b/registry/model/qwen2-5-72b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 570683,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 86208,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-7b.json
+++ b/registry/model/qwen2-5-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-coder-14b.json
+++ b/registry/model/qwen2-5-coder-14b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 568028,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 157718,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-coder-3b.json
+++ b/registry/model/qwen2-5-coder-3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 246097,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 78783,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-coder-7b-instruct-bnb-4bit.json
+++ b/registry/model/qwen2-5-coder-7b-instruct-bnb-4bit.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 4904,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 966,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-coder-7b.json
+++ b/registry/model/qwen2-5-coder-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 21583221,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2343447,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-5-vl-7b-instruct.json
+++ b/registry/model/qwen2-5-vl-7b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1678129,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 161752,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen2-72b-instruct-q4km.json
+++ b/registry/model/qwen2-72b-instruct-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-0-6b-base.json
+++ b/registry/model/qwen3-0-6b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 200965836,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 22182252,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-0-6b.json
+++ b/registry/model/qwen3-0-6b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 445878,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 75208,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-1-7b-base.json
+++ b/registry/model/qwen3-1-7b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 59624691,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3764190,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-1-7b.json
+++ b/registry/model/qwen3-1-7b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 324611,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 46919,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-14b-base.json
+++ b/registry/model/qwen3-14b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 26719961,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1805300,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-14b.json
+++ b/registry/model/qwen3-14b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 26719961,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1805300,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-235b-a22b-thinking-2507.json
+++ b/registry/model/qwen3-235b-a22b-thinking-2507.json
@@ -1,6 +1,12 @@
 {
   "active_params": 22,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 634214,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 13196,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-235b-a22b-ud-q3kxl.json
+++ b/registry/model/qwen3-235b-a22b-ud-q3kxl.json
@@ -1,6 +1,12 @@
 {
   "active_params": 22.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/qwen3-30b-a3b-base.json
+++ b/registry/model/qwen3-30b-a3b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 20067041,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2375419,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-30b-a3b-instruct-2507-awq-4bit.json
+++ b/registry/model/qwen3-30b-a3b-instruct-2507-awq-4bit.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 40949,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 57,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-30b-a3b-instruct-2507.json
+++ b/registry/model/qwen3-30b-a3b-instruct-2507.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 272529,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 12686,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-30b-a3b-thinking-2507.json
+++ b/registry/model/qwen3-30b-a3b-thinking-2507.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1615431,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1307339,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-32b.json
+++ b/registry/model/qwen3-32b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-4b-base.json
+++ b/registry/model/qwen3-4b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 76278486,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5837970,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-4b-thinking-2507.json
+++ b/registry/model/qwen3-4b-thinking-2507.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 314606,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 20200,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-0-8b-base.json
+++ b/registry/model/qwen3-5-0-8b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 16572266,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2430167,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-0-8b-q8-0-gguf.json
+++ b/registry/model/qwen3-5-0-8b-q8-0-gguf.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 479,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 69,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-0-8b.json
+++ b/registry/model/qwen3-5-0-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 95775,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6591,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-122b-a10b-reap-20.json
+++ b/registry/model/qwen3-5-122b-a10b-reap-20.json
@@ -1,6 +1,12 @@
 {
   "active_params": 10,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 14132,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 368,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-5-122b-a10b.json
+++ b/registry/model/qwen3-5-122b-a10b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 10,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 6766598,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1003508,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-5-27b-uncensored-hauhaucs-aggressive.json
+++ b/registry/model/qwen3-5-27b-uncensored-hauhaucs-aggressive.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1142286,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 64727,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-27b.json
+++ b/registry/model/qwen3-5-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 18071468,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2500255,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-2b-base.json
+++ b/registry/model/qwen3-5-2b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 12771216,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2835833,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-35b-a3b-base.json
+++ b/registry/model/qwen3-5-35b-a3b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 18037199,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2467714,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-5-35b-a3b.json
+++ b/registry/model/qwen3-5-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/qwen3-5-4b-base.json
+++ b/registry/model/qwen3-5-4b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 40883935,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 7499603,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-4b-uncensored-hauhaucs-aggressive.json
+++ b/registry/model/qwen3-5-4b-uncensored-hauhaucs-aggressive.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1148906,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 218494,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-4b.json
+++ b/registry/model/qwen3-5-4b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 40883935,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 7499603,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-9b-base.json
+++ b/registry/model/qwen3-5-9b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1515007,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 408156,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-9b-heretic-v2.json
+++ b/registry/model/qwen3-5-9b-heretic-v2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 296685,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 286177,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-5-9b.json
+++ b/registry/model/qwen3-5-9b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 57038441,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 12584452,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-aeon-ultimate-uncensored-bf16.json
+++ b/registry/model/qwen3-6-27b-aeon-ultimate-uncensored-bf16.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 84683,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5153,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-aeon-ultimate-uncensored.json
+++ b/registry/model/qwen3-6-27b-aeon-ultimate-uncensored.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 84683,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5153,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-dflash.json
+++ b/registry/model/qwen3-6-27b-dflash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 452002,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 156892,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-nvfp4.json
+++ b/registry/model/qwen3-6-27b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 3000250,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 703992,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-rocmfp4-ciru-chaos-speed.json
+++ b/registry/model/qwen3-6-27b-rocmfp4-ciru-chaos-speed.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 0,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 0,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved.json
+++ b/registry/model/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 66209,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3138,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-27b.json
+++ b/registry/model/qwen3-6-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 24822118,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5651249,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-4bit-dwq.json
+++ b/registry/model/qwen3-6-35b-a3b-4bit-dwq.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 33378,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1939,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-6-35b-a3b-abliterated-v4.json
+++ b/registry/model/qwen3-6-35b-a3b-abliterated-v4.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 85795,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 15764,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-6-35b-a3b-claude-4-6-opus-reasoning-distilled.json
+++ b/registry/model/qwen3-6-35b-a3b-claude-4-6-opus-reasoning-distilled.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 718957,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 287395,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-6-35b-a3b-heretic.json
+++ b/registry/model/qwen3-6-35b-a3b-heretic.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1133806,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 633222,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-nsc-ace-saber.json
+++ b/registry/model/qwen3-6-35b-a3b-nsc-ace-saber.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 35298,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 964,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-nvfp4.json
+++ b/registry/model/qwen3-6-35b-a3b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 29366478,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 10805863,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-ud-iq2xxs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq2xxs.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-ud-iq3xxs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq3xxs.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-ud-iq4xs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq4xs.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3.0,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "url": {
       "provenance": {

--- a/registry/model/qwen3-6-35b-a3b-uncensored-heretic-native-mtp-preserved.json
+++ b/registry/model/qwen3-6-35b-a3b-uncensored-heretic-native-mtp-preserved.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 89246,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5928,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-6-35b-a3b.json
+++ b/registry/model/qwen3-6-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 26055126,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4913916,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-6-35b-reap-pruned-ratio-0-5.json
+++ b/registry/model/qwen3-6-35b-reap-pruned-ratio-0-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 526,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 142,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-6-40b-claude-4-6-opus-deckard-heretic-uncensored-thinking.json
+++ b/registry/model/qwen3-6-40b-claude-4-6-opus-deckard-heretic-uncensored-thinking.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1891149,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 469339,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-cold-fusion-gain-v1-1.json
+++ b/registry/model/qwen3-8-27b-cold-fusion-gain-v1-1.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 11063,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 11063,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-fable-distill.json
+++ b/registry/model/qwen3-8-27b-fable-distill.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 19621,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 19621,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-nvfp4-bf16-lmhead.json
+++ b/registry/model/qwen3-8-27b-nvfp4-bf16-lmhead.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 76816,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 76816,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-nvfp4.json
+++ b/registry/model/qwen3-8-27b-nvfp4.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 2429367,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 2429367,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-ud-q4km.json
+++ b/registry/model/qwen3-8-27b-ud-q4km.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b-uncensored-int4-autoround.json
+++ b/registry/model/qwen3-8-27b-uncensored-int4-autoround.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 850,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 850,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-27b.json
+++ b/registry/model/qwen3-8-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 4720763,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4720763,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-9b-distill.json
+++ b/registry/model/qwen3-8-9b-distill.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 325888,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 325888,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8-flash-next.json
+++ b/registry/model/qwen3-8-flash-next.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 108962,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 108962,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8b-base.json
+++ b/registry/model/qwen3-8b-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 115447134,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 13643917,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-8b.json
+++ b/registry/model/qwen3-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1382160,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 345133,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-coder-30b-a3b-instruct-fp8.json
+++ b/registry/model/qwen3-coder-30b-a3b-instruct-fp8.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 7362906,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1109362,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-coder-30b-a3b-instruct.json
+++ b/registry/model/qwen3-coder-30b-a3b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 14895829,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 774811,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-coder-next-fp8.json
+++ b/registry/model/qwen3-coder-next-fp8.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 9131156,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1762681,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-coder-next.json
+++ b/registry/model/qwen3-coder-next.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 6350702,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 447978,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3-next-80b-a3b-instruct.json
+++ b/registry/model/qwen3-next-80b-a3b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 263388,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6827,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-vl-30b-a3b-instruct.json
+++ b/registry/model/qwen3-vl-30b-a3b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 898359,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 43954,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwen3-vl-8b-instruct.json
+++ b/registry/model/qwen3-vl-8b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 53999830,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 8958812,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwen3.json
+++ b/registry/model/qwen3.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": null,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": null,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwopus3-5-9b-v3-5.json
+++ b/registry/model/qwopus3-5-9b-v3-5.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 680143,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 292701,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwopus3-6-27b-v2.json
+++ b/registry/model/qwopus3-6-27b-v2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 703637,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 358056,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwopus3-6-35b-a3b-v1.json
+++ b/registry/model/qwopus3-6-35b-a3b-v1.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 1167444,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 445697,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/qwythos-9b-claude-mythos-5-1m.json
+++ b/registry/model/qwythos-9b-claude-mythos-5-1m.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 22862,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 5056,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/qwythos-9b-v2.json
+++ b/registry/model/qwythos-9b-v2.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 1008892,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 530593,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/reka-flash-3.json
+++ b/registry/model/reka-flash-3.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 21245,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 472,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/seed-oss-36b-instruct.json
+++ b/registry/model/seed-oss-36b-instruct.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 104617,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 4628,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/step-3-7-flash.json
+++ b/registry/model/step-3-7-flash.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": null,
+  "downloads": {
+    "all_time": 369038,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 38822,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ternary-bonsai-8b-unpacked.json
+++ b/registry/model/ternary-bonsai-8b-unpacked.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 81860,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 17242,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/tess-4-35b-a3b.json
+++ b/registry/model/tess-4-35b-a3b.json
@@ -1,6 +1,12 @@
 {
   "active_params": 3,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 100,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 56,
+    "source": "huggingface-api"
+  },
   "facts": {},
   "family": "qwen",
   "huggingface": {

--- a/registry/model/thinkingcap-qwen3-6-27b.json
+++ b/registry/model/thinkingcap-qwen3-6-27b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 42899,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 6087,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/trinity-mini-base.json
+++ b/registry/model/trinity-mini-base.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 114181,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 20197,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/ui-tars-7b-dpo.json
+++ b/registry/model/ui-tars-7b-dpo.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 61113,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 1821,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/unlimited-ocr.json
+++ b/registry/model/unlimited-ocr.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "moe",
+  "downloads": {
+    "all_time": 6688593,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 3107972,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/webworld-14b.json
+++ b/registry/model/webworld-14b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 571,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 110,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/model/webworld-8b.json
+++ b/registry/model/webworld-8b.json
@@ -1,6 +1,12 @@
 {
   "active_params": null,
   "architecture": "dense",
+  "downloads": {
+    "all_time": 740,
+    "captured_at": "2026-08-31T12:36:33Z",
+    "last_30d": 159,
+    "source": "huggingface-api"
+  },
   "facts": {
     "active_params": {
       "provenance": {

--- a/registry/schema/model.schema.json
+++ b/registry/schema/model.schema.json
@@ -14,7 +14,8 @@
     "url",
     "huggingface",
     "provenance",
-    "facts"
+    "facts",
+    "downloads"
   ],
   "properties": {
     "schema_version": {
@@ -63,6 +64,40 @@
     },
     "facts": {
       "$ref": "common.schema.json#/$defs/facts"
+    },
+    "downloads": {
+      "type": "object",
+      "required": [
+        "last_30d",
+        "all_time",
+        "captured_at",
+        "source"
+      ],
+      "properties": {
+        "last_30d": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "all_time": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "captured_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source": {
+          "const": "huggingface-api"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Hugging Face download counts for the canonical repository; null when the model has no known repo."
     }
   },
   "additionalProperties": false

--- a/registry/schema/types.ts
+++ b/registry/schema/types.ts
@@ -209,6 +209,15 @@ export interface Model {
   huggingface: HuggingfaceIdentity
   provenance: Provenance
   facts: Facts
+  /**
+   * Hugging Face download counts for the canonical repository; null when the model has no known repo.
+   */
+  downloads: {
+    last_30d: number | null
+    all_time: number | null
+    captured_at: string
+    source: "huggingface-api"
+  }
 }
 export interface ModelInstance {
   schema_version: "local-ai-registry/v1"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,7 @@ pipeline before committing.
 | 1. Import | `import_hf_benchmarks.py` | HF Model & Benchmark Matrix scrape | `registry/benchmark/` |
 | 1. Import | `import_market_snapshot.py` | local-ai-scanner-cli snapshot | `registry/price/` |
 | 1. Import | `fetch_extra_prices.py` | public retailer search pages | scanner-style snapshot for the market import |
+| 1. Import | `fetch_hf_downloads.py` | public Hugging Face API | `model.downloads` (30-day + all-time counts; drives the models-page sort) |
 | 1. Import | `import_verified_sources.py` | LocalMaxxing / Mia Labs / mlx.fast / HF configs | candidate + validated recipes |
 | 2. Tokenize | `tokenize_observed_command.py` | observed shell strings on records | `metadata.<source>.tokenized` (never the launch contract) |
 | 3. Enrich | `enrich_registry.py` | records | shared enrichment contract fields (facts, provenance) |

--- a/scripts/fetch_hf_downloads.py
+++ b/scripts/fetch_hf_downloads.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Refresh Hugging Face download counts on model records.
+
+For every model with a known huggingface.repository, fetches the repo's
+30-day and all-time download counts from the public HF API and stores them
+at model.downloads. Models without a repository (or whose repo the API does
+not know) get explicit nulls — never guesses. Run from the repository root;
+finish with format + validate before committing.
+"""
+
+import concurrent.futures
+import datetime as dt
+import glob
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://huggingface.co/api/models/{repo}?expand[]=downloads&expand[]=downloadsAllTime"
+CONTEXT = ssl.create_default_context()
+
+
+def fetch(repo):
+    request = urllib.request.Request(API.format(repo=repo), headers={"User-Agent": "local-ai-registry/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=20, context=CONTEXT) as response:
+            payload = json.load(response)
+        return repo, payload.get("downloads"), payload.get("downloadsAllTime"), None
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError) as error:
+        return repo, None, None, str(error)
+
+
+def main() -> int:
+    captured_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    paths = sorted(glob.glob("registry/model/*.json"))
+    records = {p: json.load(open(p)) for p in paths}
+    repos = {}
+    for p, d in records.items():
+        repo = (d.get("huggingface") or {}).get("repository")
+        if isinstance(repo, str) and repo:
+            repos.setdefault(repo, []).append(p)
+
+    results = {}
+    errors = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        for repo, d30, dall, error in pool.map(fetch, sorted(repos)):
+            results[repo] = (d30, dall)
+            if error:
+                errors += 1
+                print(f"WARN {repo}: {error}", file=sys.stderr)
+
+    for p, d in records.items():
+        repo = (d.get("huggingface") or {}).get("repository")
+        d30, dall = results.get(repo, (None, None))
+        d["downloads"] = {
+            "last_30d": d30,
+            "all_time": dall,
+            "captured_at": captured_at,
+            "source": "huggingface-api",
+        }
+        open(p, "w").write(json.dumps(d, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+    known = sum(1 for r in results.values() if r[0] is not None)
+    print(f"models: {len(paths)}; repos queried: {len(repos)}; with 30d counts: {known}; fetch errors: {errors}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `model.downloads` (30-day + all-time Hugging Face counts, capture-stamped, 254/283 models covered, explicit nulls elsewhere), refreshed via `make downloads`. `listModels` sorts by 30-day downloads descending (name tiebreak) and the models list shows the count. Top of the page is now Qwen3-0.6B-Base at 22.2M/month instead of alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)