### PR TITLE
Restore detail pages and card components (unmerged UI branch)

### DIFF
--- a/app/[collection]/[id]/page.tsx
+++ b/app/[collection]/[id]/page.tsx
@@ -2,133 +2,70 @@ import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 
-import { DataTree } from "@/app/components/data-tree"
-import { ConfigurationCard, configurationFromRecipe } from "@/app/components/configuration-card"
-import { HuggingFaceCard } from "@/app/components/huggingface-card"
+import { CollectionNav } from "@/app/components/collection-nav"
+import { RecordBody } from "@/app/components/record-body"
+import {
+  collectionHref,
+  collectionLabel,
+  collectionTopic,
+  isCollection,
+} from "@/app/lib/catalog"
+import { huggingFaceIdentity, recordTitle } from "@/app/lib/record-view"
 import { getEntityDetail } from "@/lib/registry"
 
 export const dynamic = "force-dynamic"
-
-const COLLECTION_LABELS: Record<string, string> = {
-  hardware: "Hardware",
-  "model-instances": "Model instance",
-  models: "Model",
-  prices: "Regional market price",
-  recipes: "Recipe",
-  benchmarks: "Leaderboard",
-  "speed-sweeps": "Speed sweep",
-}
-
-const COLLECTION_TOPICS: Record<string, string> = {
-  hardware: "hardware",
-  "model-instances": "recipes",
-  models: "models",
-  prices: "prices",
-  recipes: "recipes",
-  benchmarks: "benchmarks",
-  "speed-sweeps": "speed-sweeps",
-}
 
 type DetailProps = {
   params: Promise<{ collection: string; id: string }>
 }
 
-type HuggingFaceDisplay = {
-  linkType: "repository" | "search"
-  status: "known" | "unknown" | "unavailable"
-  url: string
-}
-
-function readHuggingFace(record: Record<string, unknown>): HuggingFaceDisplay | null {
-  const value = record.huggingface
-  if (!value || typeof value !== "object") return null
-  if (!("url" in value) || !("status" in value) || !("link_type" in value)) return null
-  const { link_type: linkType, status, url } = value
-  if (typeof url !== "string" || url.length === 0) return null
-  if (status !== "known" && status !== "unknown" && status !== "unavailable") return null
-  if (linkType !== "repository" && linkType !== "search") return null
-  return { linkType, status, url }
-}
-
 export async function generateMetadata({ params }: DetailProps): Promise<Metadata> {
   const { collection, id } = await params
-  if (!COLLECTION_LABELS[collection]) return { title: "Record not found" }
+  if (!isCollection(collection)) return { title: "Record not found" }
   const detail = getEntityDetail(collection, id)
   if (!detail) return { title: "Record not found" }
-  const product = detail.product && typeof detail.product === "object" && "name" in detail.product ? detail.product.name : null
-  const title = String(detail.name ?? detail.repository ?? product ?? detail.id ?? id)
-  return { title: `${title} · Local AI Registry` }
+  return { title: `${recordTitle(detail, id)} · Local AI Registry` }
 }
 
 export default async function DetailPage({ params }: DetailProps) {
   const { collection, id } = await params
-  const collectionLabel = COLLECTION_LABELS[collection]
-  if (!collectionLabel) notFound()
+  const label = collectionLabel(collection)
+  if (!label || !isCollection(collection)) notFound()
   const detail = getEntityDetail(collection, id)
   if (!detail) notFound()
-
-  const product = detail.product && typeof detail.product === "object" && "name" in detail.product ? detail.product.name : null
-  const title = String(detail.name ?? detail.repository ?? product ?? detail.id ?? id)
-  if (collection === "model-instances" && !readHuggingFace(detail)) {
+  if (collection === "model-instances" && !huggingFaceIdentity(detail)?.url) {
     throw new Error(`Model instance '${id}' lacks its authoritative Hugging Face identity`)
   }
-  const huggingFace = detail.huggingface && typeof detail.huggingface === "object" ? detail.huggingface as {
-    link_type?: string
-    reason?: string | { code: string; detail: string }
-    repository?: string | null
-    status?: string
-    url?: string
-  } : null
-  const showRecipeSearch = collection === "recipes" || collection === "hardware" || collection === "models" || collection === "model-instances"
-  const treeRecord = Object.fromEntries(Object.entries(detail).filter(([key]) => key !== "launch" && key !== "huggingface"))
-  const config = collection === "recipes" ? configurationFromRecipe(detail) : null
-  const topic = COLLECTION_TOPICS[collection]
-  const collectionHref = `/?topic=${encodeURIComponent(topic)}`
-  const recipeSearchHref = `/?topic=recipes&q=${encodeURIComponent(title)}`
-  const collectionSearchHref = `${collectionHref}&q=${encodeURIComponent(title)}`
+
+  const title = recordTitle(detail, id)
+  const topic = collectionTopic(collection)
+  const collectionBrowse = collectionHref(collection)
+  const recipeSearch = collection === "recipes" || collection === "hardware" || collection === "models" || collection === "model-instances"
 
   return (
     <main className="detail-page">
+      <CollectionNav current={topic} />
       <nav className="breadcrumbs" aria-label="Breadcrumb">
         <Link href="/">Registry</Link>
         <span>/</span>
-        <Link href={collectionHref}>{collectionLabel}</Link>
+        <Link href={collectionBrowse}>{label}</Link>
         <span>/</span>
         <span>{title}</span>
       </nav>
       <header className="detail-header">
-        <p className="eyebrow">{collectionLabel}</p>
+        <p className="eyebrow">{label}</p>
         <h1>{title}</h1>
         <code>{id}</code>
         <div className="detail-actions">
           <a href={`/api/v1/${collection}/${id}`}>JSON API</a>
-          {showRecipeSearch ? (
-            <Link href={recipeSearchHref}>Find compatible recipes</Link>
+          {recipeSearch ? (
+            <Link href={`/?topic=recipes&q=${encodeURIComponent(title)}`}>Find compatible recipes</Link>
           ) : (
-            <Link href={collectionSearchHref}>Back to {collectionLabel.toLowerCase()} search</Link>
+            <Link href={`${collectionBrowse}&q=${encodeURIComponent(title)}`}>Back to {label.toLowerCase()} search</Link>
           )}
         </div>
       </header>
-
-      <HuggingFaceCard identity={huggingFace} />
-      {config && (
-        <>
-          <p className="trust-note">
-            {detail.status === "validated" && detail.registry && typeof detail.registry === "object" && "launchable" in detail.registry && detail.registry.launchable
-              ? "Validated: pinned artifact, pinned runtime, and accepted evidence. This is a launch contract."
-              : "Candidate: useful compatibility or speed evidence. The registry does not offer Run until promotion requirements are met."}
-          </p>
-          <ConfigurationCard config={config} />
-        </>
-      )}
-
-      <section className="record-sheet">
-        <div className="record-sheet-heading">
-          <h2>Complete normalized record</h2>
-          <p>Launch contracts are shown as configuration cards above. Remaining fields stay in page flow.</p>
-        </div>
-        <DataTree value={treeRecord} />
-      </section>
+      <RecordBody collection={collection} record={detail} variant="page" />
     </main>
   )
 }

--- a/app/components/browse-rows.tsx
+++ b/app/components/browse-rows.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import type { ReactNode } from "react"
 
-import { hrefWithFilter, hrefWithRecord } from "@/app/lib/catalog"
+import { hrefWithFilter, recordHref } from "@/app/lib/catalog"
 import {
   getSpeedSweep,
   marketPriceCount,
@@ -92,7 +92,7 @@ function BrowserRow({
 }) {
   return (
     <article className={`browser-row ${className}`}>
-      <Link aria-label={label} className="row-open" href={href} scroll={false} />
+      <Link aria-label={label} className="row-open" href={href} />
       {status && <span className={`status-mark ${status}`} aria-hidden="true" />}
       {children}
       <TaxonomyTags state={state} tags={tags} />
@@ -131,7 +131,7 @@ export function RecipeRows({ by, data, state }: { by: "hardware" | "model"; data
         return (
           <BrowserRow
             className="recipe-browser-row"
-            href={hrefWithRecord(state, result.id)}
+            href={recordHref("recipes", result.id)}
             key={result.id}
             label={`Open ${result.model.name} recipe`}
             state={state}
@@ -166,7 +166,7 @@ export function PriceRows({ data, state }: { data: PriceResult[]; state: URLSear
         return (
           <BrowserRow
             className="price-row"
-            href={hrefWithRecord(state, record.id)}
+            href={recordHref("prices", record.id)}
             key={record.id}
             label={`Open ${record.product.name} market observations`}
             state={state}
@@ -200,7 +200,7 @@ export function HardwareRows({ data, state }: { data: Hardware[]; state: URLSear
         return (
           <BrowserRow
             className="collection-row"
-            href={hrefWithRecord(state, hardware.id)}
+            href={recordHref("hardware", hardware.id)}
             key={hardware.id}
             label={`Open ${hardware.name}`}
             state={state}
@@ -228,7 +228,7 @@ export function ModelRows({ data, state }: { data: Model[]; state: URLSearchPara
         return (
           <BrowserRow
             className="collection-row"
-            href={hrefWithRecord(state, model.id)}
+            href={recordHref("models", model.id)}
             key={model.id}
             label={`Open ${model.name}`}
             state={state}
@@ -256,7 +256,7 @@ export function BenchmarkRows({ data, state }: { data: Benchmark[]; state: URLSe
         return (
           <BrowserRow
             className="collection-row"
-            href={hrefWithRecord(state, benchmark.id)}
+            href={recordHref("benchmarks", benchmark.id)}
             key={benchmark.id}
             label={`Open ${benchmark.id}`}
             state={state}
@@ -284,7 +284,7 @@ export function SweepRows({ data, state }: { data: SpeedSweep[]; state: URLSearc
         return (
           <BrowserRow
             className="collection-row"
-            href={hrefWithRecord(state, sweep.id)}
+            href={recordHref("speed-sweeps", sweep.id)}
             key={sweep.id}
             label={`Open ${sweep.id}`}
             state={state}

--- a/app/components/browse-rows.tsx
+++ b/app/components/browse-rows.tsx
@@ -1,0 +1,302 @@
+import Link from "next/link"
+import type { ReactNode } from "react"
+
+import { hrefWithFilter, hrefWithRecord } from "@/app/lib/catalog"
+import {
+  getSpeedSweep,
+  marketPriceCount,
+  recipeCountForHardware,
+  runtimeGroup,
+  type CompatibilityResult,
+  type PriceResult,
+} from "@/lib/registry"
+import type { Benchmark, Hardware, Model, SpeedSweep } from "@/registry/schema/types"
+
+export type RowTag = {
+  label: string
+  name: string
+  value: string
+}
+
+const USD_FORMATTER = new Intl.NumberFormat("en-US", {
+  currency: "USD",
+  maximumFractionDigits: 0,
+  style: "currency",
+})
+
+function numberField(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function formatTokens(value: number | null): string {
+  if (value === null) return "Unknown context"
+  if (value >= 1024) {
+    const thousands = value / 1024
+    return `${Number.isInteger(thousands) ? thousands : thousands.toFixed(1)}K`
+  }
+  return value.toLocaleString()
+}
+
+function formatRate(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
+function formatAmount(amount: number, currency: string): string {
+  return currency === "USD" ? USD_FORMATTER.format(amount) : `${currency} ${amount.toLocaleString()}`
+}
+
+function peakSpeed(rows: Array<{ decode_tok_s_per_stream?: number | null; decode_tok_s?: number | null; prefill_tok_s?: number | null }>): number | null {
+  const values = rows.flatMap((row) => {
+    const value = row.decode_tok_s_per_stream ?? row.decode_tok_s ?? row.prefill_tok_s
+    return typeof value === "number" ? [value] : []
+  })
+  return values.length > 0 ? Math.max(...values) : null
+}
+
+function recipeEvidence(result: CompatibilityResult) {
+  return result.recipe.speed_sweeps_ids.flatMap((sweepId) => {
+    const sweep = getSpeedSweep(sweepId)
+    return sweep ? sweep.rows : []
+  })
+}
+
+function TaxonomyTags({ state, tags }: { state: URLSearchParams; tags: RowTag[] }) {
+  return (
+    <span className="taxonomy-tags">
+      {tags.slice(0, 4).map((tag) => (
+        <Link aria-label={`Filter by ${tag.label}`} href={hrefWithFilter(state, tag.name, tag.value)} key={`${tag.name}:${tag.value}`}>
+          {tag.label}
+        </Link>
+      ))}
+    </span>
+  )
+}
+
+function BrowserRow({
+  children,
+  className,
+  href,
+  label,
+  state,
+  status,
+  tags,
+}: {
+  children: ReactNode
+  className: string
+  href: string
+  label: string
+  state: URLSearchParams
+  status?: "validated" | "candidate"
+  tags: RowTag[]
+}) {
+  return (
+    <article className={`browser-row ${className}`}>
+      <Link aria-label={label} className="row-open" href={href} scroll={false} />
+      {status && <span className={`status-mark ${status}`} aria-hidden="true" />}
+      {children}
+      <TaxonomyTags state={state} tags={tags} />
+      <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
+    </article>
+  )
+}
+
+export function RecipeRows({ by, data, state }: { by: "hardware" | "model"; data: CompatibilityResult[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list recipe-browser-list">
+      {data.map((result) => {
+        const context = numberField(result.recipe.serving, "max_context_tokens")
+        const speed = peakSpeed(recipeEvidence(result))
+        const validation = result.launchable ? "validated" : "candidate"
+        const runtime = runtimeGroup(result.recipe.launch.kind)
+        const tags: RowTag[] = [
+          { label: validation, name: "validation", value: validation },
+          { label: result.recipe.engine.name, name: "engine", value: result.recipe.engine.name },
+          { label: runtime === "docker" ? "docker" : runtime === "native" ? "no docker" : "evidence", name: "runtime", value: runtime },
+          { label: result.speed_evidence.available ? "measured" : "unmeasured", name: "evidence", value: String(result.speed_evidence.available) },
+          { label: `${result.hardware.memory.vram_gb} GB+`, name: "min_vram_gb", value: String(result.hardware.memory.vram_gb) },
+        ]
+        const hardware = (
+          <span className={by === "hardware" ? "row-primary" : undefined}>
+            <strong>{result.hardware.name}</strong>
+            <small>{result.recipe.hardware_count} × {result.hardware.memory.vram_gb} GB</small>
+          </span>
+        )
+        const model = (
+          <span className={by === "model" ? "row-primary" : undefined}>
+            <strong>{result.model.name}</strong>
+            <small>{result.model_instance.weights.precision ?? result.model_instance.weights.format ?? "Unknown precision"}</small>
+          </span>
+        )
+        return (
+          <BrowserRow
+            className="recipe-browser-row"
+            href={hrefWithRecord(state, result.id)}
+            key={result.id}
+            label={`Open ${result.model.name} recipe`}
+            state={state}
+            status={validation}
+            tags={tags}
+          >
+            {by === "hardware" ? hardware : model}
+            {by === "hardware" ? model : hardware}
+            <span><strong>{result.recipe.engine.name}</strong><small>{result.recipe.launch.kind}</small></span>
+            <span><strong>{formatTokens(context)}</strong><small>context</small></span>
+            <span><strong>{speed === null ? "—" : `${formatRate(speed)} tok/s`}</strong><small>{result.speed_evidence.available ? "measured" : "no evidence"}</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}
+
+export function PriceRows({ data, state }: { data: PriceResult[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list collection-list">
+      {data.map((record) => {
+        const amount = record.summary.lowest_new ?? record.summary.lowest_refurbished ?? record.summary.lowest_used
+        const condition = record.summary.lowest_new !== null
+          ? "new"
+          : record.summary.lowest_refurbished !== null ? "refurbished" : record.summary.lowest_used !== null ? "used" : "unavailable"
+        const tags: RowTag[] = [
+          { label: record.region.code, name: "region", value: record.region.code },
+          { label: record.product.category, name: "category", value: record.product.category },
+          { label: condition, name: "condition", value: condition },
+        ]
+        return (
+          <BrowserRow
+            className="price-row"
+            href={hrefWithRecord(state, record.id)}
+            key={record.id}
+            label={`Open ${record.product.name} market observations`}
+            state={state}
+            tags={tags}
+          >
+            <span className="row-primary"><strong>{record.product.name}</strong><small>{record.product.id}</small></span>
+            <span><strong>{amount === null ? "No available listing" : formatAmount(amount, record.region.currency)}</strong><small>lowest available · {condition}</small></span>
+            <span><strong>{record.region.name}</strong><small>{record.region.currency}</small></span>
+            <span><strong>{record.observed_at.slice(0, 10)}</strong><small>observed</small></span>
+            <span><strong>{record.summary.listing_count} listings</strong><small>{record.summary.retailer_count} retailers</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}
+
+export function HardwareRows({ data, state }: { data: Hardware[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list collection-list">
+      {data.map((hardware) => {
+        const hasPrices = marketPriceCount(hardware.id) > 0
+        const recipes = recipeCountForHardware(hardware.id)
+        const tags: RowTag[] = [
+          { label: hardware.vendor, name: "vendor", value: hardware.vendor },
+          { label: hardware.accelerator_backend, name: "backend", value: hardware.accelerator_backend },
+          { label: `${hardware.memory.vram_gb} GB+`, name: "min_vram_gb", value: String(hardware.memory.vram_gb) },
+          ...(hasPrices ? [{ label: "priced", name: "priced_only", value: "true" }] : []),
+          { label: recipes > 0 ? `${recipes} recipes` : "no recipes", name: "has_recipes", value: recipes > 0 ? "true" : "false" },
+        ]
+        return (
+          <BrowserRow
+            className="collection-row"
+            href={hrefWithRecord(state, hardware.id)}
+            key={hardware.id}
+            label={`Open ${hardware.name}`}
+            state={state}
+            tags={tags}
+          >
+            <span className="row-primary"><strong>{hardware.name}</strong><small>{hardware.id}</small></span>
+            <span><strong>{hardware.vendor}</strong><small>{hardware.kind}</small></span>
+            <span><strong>{hardware.memory.vram_gb} GB</strong><small>{hardware.memory.vram_type ?? "Memory type unknown"}</small></span>
+            <span><strong>{recipes.toLocaleString()}</strong><small>{recipes === 1 ? "recipe" : "recipes"}</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}
+
+export function ModelRows({ data, state }: { data: Model[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list collection-list">
+      {data.map((model) => {
+        const tags: RowTag[] = [
+          { label: model.family, name: "family", value: model.family },
+          { label: model.architecture ?? "unknown", name: "architecture", value: model.architecture ?? "unknown" },
+        ]
+        return (
+          <BrowserRow
+            className="collection-row"
+            href={hrefWithRecord(state, model.id)}
+            key={model.id}
+            label={`Open ${model.name}`}
+            state={state}
+            tags={tags}
+          >
+            <span className="row-primary"><strong>{model.name}</strong><small>{model.id}</small></span>
+            <span><strong>{model.family}</strong><small>family</small></span>
+            <span><strong>{model.architecture ?? "Unknown"}</strong><small>architecture</small></span>
+            <span><strong>{model.params ?? "—"}</strong><small>parameters</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}
+
+export function BenchmarkRows({ data, state }: { data: Benchmark[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list collection-list">
+      {data.map((benchmark) => {
+        const top = benchmark.rows[0]
+        const tags: RowTag[] = [
+          ...(benchmark.category ? [{ label: benchmark.category, name: "category", value: benchmark.category }] : []),
+        ]
+        return (
+          <BrowserRow
+            className="collection-row"
+            href={hrefWithRecord(state, benchmark.id)}
+            key={benchmark.id}
+            label={`Open ${benchmark.id}`}
+            state={state}
+            tags={tags}
+          >
+            <span className="row-primary"><strong>{benchmark.name}</strong><small>{benchmark.id}</small></span>
+            <span><strong>{benchmark.category ?? "Unknown"}</strong><small>category</small></span>
+            <span><strong>{benchmark.rows.length}</strong><small>scored models</small></span>
+            <span><strong>{top ? (top.score === null ? "—" : formatRate(top.score)) : "—"}</strong><small>top score</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}
+
+export function SweepRows({ data, state }: { data: SpeedSweep[]; state: URLSearchParams }) {
+  return (
+    <div className="browser-list collection-list">
+      {data.map((sweep) => {
+        const speed = peakSpeed(sweep.rows)
+        const tags: RowTag[] = [
+          { label: sweep.recipe_id, name: "recipe_id", value: sweep.recipe_id },
+        ]
+        return (
+          <BrowserRow
+            className="collection-row"
+            href={hrefWithRecord(state, sweep.id)}
+            key={sweep.id}
+            label={`Open ${sweep.id}`}
+            state={state}
+            tags={tags}
+          >
+            <span className="row-primary"><strong>{sweep.id}</strong><small>{sweep.recipe_id}</small></span>
+            <span><strong>{sweep.measured_at ?? "Unknown"}</strong><small>measured</small></span>
+            <span><strong>{sweep.rows.length}</strong><small>points</small></span>
+            <span><strong>{speed === null ? "—" : `${formatRate(speed)} tok/s`}</strong><small>peak recorded</small></span>
+          </BrowserRow>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/components/collection-nav.tsx
+++ b/app/components/collection-nav.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link"
+
+import { TOPICS, topicHref, type Topic } from "@/app/lib/catalog"
+
+export function CollectionNav({ current, query = "" }: { current?: Topic | ""; query?: string }) {
+  return (
+    <nav aria-label="Registry collections" className="topic-tabs">
+      {TOPICS.map((item) => (
+        <Link aria-current={current === item.key ? "page" : undefined} href={topicHref(item.key, query)} key={item.key}>
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/app/components/copy-actions.tsx
+++ b/app/components/copy-actions.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useState } from "react"
+
+import type { CopyItem } from "@/app/lib/record-view"
+
+export function CopyActions({ items }: { items: CopyItem[] }) {
+  const [copied, setCopied] = useState<string | null>(null)
+  if (items.length === 0) return null
+
+  async function copy(item: CopyItem) {
+    await navigator.clipboard.writeText(item.value)
+    setCopied(item.label)
+    window.setTimeout(() => setCopied((current) => current === item.label ? null : current), 1600)
+  }
+
+  return (
+    <div className="copy-actions" aria-label="Copy record fields">
+      {items.map((item) => (
+        <button key={item.label} onClick={() => copy(item)} type="button">
+          Copy {item.label.toLowerCase()}
+        </button>
+      ))}
+      <span className="copy-status" aria-live="polite">{copied ? `Copied ${copied.toLowerCase()}` : ""}</span>
+    </div>
+  )
+}

--- a/app/components/record-body.tsx
+++ b/app/components/record-body.tsx
@@ -1,0 +1,47 @@
+import { ConfigurationCard, configurationFromRecipe } from "@/app/components/configuration-card"
+import { DataTree } from "@/app/components/data-tree"
+import { HuggingFaceCard } from "@/app/components/huggingface-card"
+import { RelatedRecords } from "@/app/components/related-records"
+import { displayRecord, huggingFaceIdentity, relatedGroups, recipeIsLaunchable } from "@/app/lib/record-view"
+
+export function RecordBody({
+  collection,
+  record,
+  variant = "page",
+}: {
+  collection: string
+  record: Record<string, unknown>
+  variant?: "overlay" | "page"
+}) {
+  const recipe = collection === "recipes"
+  const config = recipe ? configurationFromRecipe(record) : null
+  const groups = relatedGroups(record)
+  const tree = displayRecord(record)
+  return (
+    <>
+      <HuggingFaceCard identity={huggingFaceIdentity(record)} />
+      {config && (
+        <>
+          <p className="trust-note">
+            {recipeIsLaunchable(record)
+              ? "Validated: pinned artifact, pinned runtime, and accepted evidence. This is a launch contract."
+              : "Candidate: useful compatibility or speed evidence. The registry does not offer Run until promotion requirements are met."}
+          </p>
+          <ConfigurationCard config={config} />
+        </>
+      )}
+      <RelatedRecords groups={groups} />
+      {variant === "page" ? (
+        <section className="record-sheet">
+          <div className="record-sheet-heading">
+            <h2>Complete normalized record</h2>
+            <p>Launch contracts, Hub identity, and related records are shown above. Remaining fields stay in page flow.</p>
+          </div>
+          <DataTree value={tree} />
+        </section>
+      ) : (
+        <DataTree value={tree} />
+      )}
+    </>
+  )
+}

--- a/app/components/record-body.tsx
+++ b/app/components/record-body.tsx
@@ -1,8 +1,19 @@
 import { ConfigurationCard, configurationFromRecipe } from "@/app/components/configuration-card"
+import { CopyActions } from "@/app/components/copy-actions"
 import { DataTree } from "@/app/components/data-tree"
 import { HuggingFaceCard } from "@/app/components/huggingface-card"
+import { RecordEvidence } from "@/app/components/record-evidence"
+import { RecordFacts } from "@/app/components/record-facts"
 import { RelatedRecords } from "@/app/components/related-records"
-import { displayRecord, huggingFaceIdentity, relatedGroups, recipeIsLaunchable } from "@/app/lib/record-view"
+import {
+  copyItems,
+  displayRecord,
+  huggingFaceIdentity,
+  recordDescription,
+  recordFacts,
+  relatedGroups,
+  recipeIsLaunchable,
+} from "@/app/lib/record-view"
 
 export function RecordBody({
   collection,
@@ -15,10 +26,16 @@ export function RecordBody({
 }) {
   const recipe = collection === "recipes"
   const config = recipe ? configurationFromRecipe(record) : null
+  const description = recordDescription(record)
+  const facts = recordFacts(collection, record)
   const groups = relatedGroups(record)
+  const copies = copyItems(collection, record)
   const tree = displayRecord(record)
   return (
     <>
+      {description && <p className="record-lede">{description}</p>}
+      <CopyActions items={copies} />
+      <RecordFacts facts={facts} />
       <HuggingFaceCard identity={huggingFaceIdentity(record)} />
       {config && (
         <>
@@ -30,12 +47,13 @@ export function RecordBody({
           <ConfigurationCard config={config} />
         </>
       )}
+      <RecordEvidence collection={collection} record={record} />
       <RelatedRecords groups={groups} />
       {variant === "page" ? (
         <section className="record-sheet">
           <div className="record-sheet-heading">
-            <h2>Complete normalized record</h2>
-            <p>Launch contracts, Hub identity, and related records are shown above. Remaining fields stay in page flow.</p>
+            <h2>Remaining fields</h2>
+            <p>Identity, launch, related records, and measured speed are shown above. This is the rest of the normalized record.</p>
           </div>
           <DataTree value={tree} />
         </section>

--- a/app/components/record-evidence.tsx
+++ b/app/components/record-evidence.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link"
+
+import { getSpeedSweep } from "@/lib/registry"
+
+type EvidenceRow = {
+  concurrency: number | null
+  context_tokens: number | null
+  decode: number | null
+  key: string
+  prefill: number | null
+  status: string
+  sweepId?: string
+  ttft: number | null
+}
+
+function asRows(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item)) : []
+}
+
+function number(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function formatRate(value: number | null): string {
+  return value === null ? "—" : value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
+function evidenceFromSweep(id: string): EvidenceRow[] {
+  const sweep = getSpeedSweep(id)
+  if (!sweep) return []
+  return sweep.rows.map((row, index) => ({
+    concurrency: row.concurrency,
+    context_tokens: row.context_tokens,
+    decode: row.decode_tok_s_per_stream ?? row.decode_tok_s,
+    key: `${id}:${index}`,
+    prefill: row.prefill_tok_s,
+    status: row.status,
+    sweepId: id,
+    ttft: row.ttft_ms_p50,
+  }))
+}
+
+function evidenceFromRecord(record: Record<string, unknown>): EvidenceRow[] {
+  const ids = Array.isArray(record.speed_sweeps_ids) ? record.speed_sweeps_ids.filter((item): item is string => typeof item === "string") : []
+  if (ids.length > 0) return ids.flatMap(evidenceFromSweep)
+  return asRows(record.rows).map((row, index) => ({
+    concurrency: number(row.concurrency),
+    context_tokens: number(row.context_tokens),
+    decode: number(row.decode_tok_s_per_stream) ?? number(row.decode_tok_s),
+    key: `row:${index}`,
+    prefill: number(row.prefill_tok_s),
+    status: typeof row.status === "string" ? row.status : typeof row.root === "string" ? row.root : "",
+    ttft: number(row.ttft_ms_p50),
+  }))
+}
+
+function benchmarkRows(record: Record<string, unknown>): Array<{ key: string; model: string; score: string }> {
+  return asRows(record.rows).slice(0, 24).map((row, index) => ({
+    key: `${String(row.root ?? row.model ?? index)}:${index}`,
+    model: String(row.root ?? row.model ?? row.name ?? "Unknown"),
+    score: number(row.score) === null ? "—" : String(number(row.score)),
+  }))
+}
+
+export function RecordEvidence({ collection, record }: { collection: string; record: Record<string, unknown> }) {
+  if (collection === "benchmarks") {
+    const rows = benchmarkRows(record)
+    if (rows.length === 0) return null
+    return (
+      <section aria-label="Leaderboard scores" className="record-evidence">
+        <p className="eyebrow">Scores</p>
+        <table className="flag-table">
+          <thead><tr><th>Model</th><th>Score</th></tr></thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.key}><td>{row.model}</td><td>{row.score}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    )
+  }
+
+  if (collection !== "recipes" && collection !== "speed-sweeps") return null
+  const rows = evidenceFromRecord(record)
+  if (rows.length === 0) return null
+  return (
+    <section aria-label="Measured speed" className="record-evidence">
+      <p className="eyebrow">Measured speed</p>
+      <table className="flag-table">
+        <thead>
+          <tr>
+            <th>Concurrency</th>
+            <th>Context</th>
+            <th>Prefill</th>
+            <th>Decode</th>
+            <th>TTFT ms</th>
+            <th>Status</th>
+            {collection === "recipes" && <th>Sweep</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key}>
+              <td>{row.concurrency ?? "—"}</td>
+              <td>{row.context_tokens?.toLocaleString() ?? "—"}</td>
+              <td>{formatRate(row.prefill)}</td>
+              <td>{formatRate(row.decode)}</td>
+              <td>{formatRate(row.ttft)}</td>
+              <td>{row.status || "—"}</td>
+              {collection === "recipes" && (
+                <td>{row.sweepId ? <Link href={`/speed-sweeps/${row.sweepId}`}>{row.sweepId}</Link> : "—"}</td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/app/components/record-facts.tsx
+++ b/app/components/record-facts.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link"
+
+import type { RecordFact } from "@/app/lib/record-view"
+
+export function RecordFacts({ facts }: { facts: RecordFact[] }) {
+  if (facts.length === 0) return null
+  return (
+    <section aria-label="Record fields" className="record-facts">
+      <p className="eyebrow">Record</p>
+      <dl>
+        {facts.map((item) => (
+          <div key={item.label}>
+            <dt>{item.label}</dt>
+            <dd>{item.href ? <Link href={item.href}>{item.value}</Link> : item.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}

--- a/app/components/related-records.tsx
+++ b/app/components/related-records.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+
+import type { RelatedGroup } from "@/app/lib/record-view"
+
+export function RelatedRecords({ groups }: { groups: RelatedGroup[] }) {
+  if (groups.length === 0) return null
+  return (
+    <nav aria-label="Related records" className="related-records">
+      <p className="eyebrow">Related records</p>
+      <dl>
+        {groups.map((group) => (
+          <div key={group.key}>
+            <dt>{group.label}</dt>
+            <dd>
+              <ul>
+                {group.links.map((link) => (
+                  <li key={link.id}><Link href={link.href}>{link.label}</Link></li>
+                ))}
+              </ul>
+              {group.moreHref && (
+                <p><Link href={group.moreHref}>All {group.total.toLocaleString()} {group.label.toLowerCase()}</Link></p>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </nav>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -419,8 +419,54 @@ code, pre, kbd, .mono-label, .row-status, .topic-total, .pagination { font-famil
 .eyebrow { margin-bottom: 8px; color: var(--muted); font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.08em; text-transform: uppercase; }
 .detail-header h1 { margin-bottom: 9px; font-size: clamp(1.35rem, 3vw, 2rem); font-weight: 600; line-height: 1.15; letter-spacing: 0; overflow-wrap: anywhere; }
 .detail-header > code { color: var(--muted); font-size: 0.68rem; overflow-wrap: anywhere; }
-.detail-actions { display: flex; gap: 8px; margin-top: 18px; }
+.detail-actions { display: flex; gap: 8px; margin-top: 18px; flex-wrap: wrap; }
 .detail-actions a { padding: 6px 9px; border: 1px solid #444441; border-radius: 3px; font-size: 0.7rem; text-decoration: none; }
+.record-lede {
+  max-width: 62rem;
+  margin: 16px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+.copy-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin: 16px 0 0;
+}
+.copy-actions button {
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.7rem;
+}
+.copy-actions button:hover { border-color: var(--ink); }
+.record-modal .copy-actions button { border-color: var(--line-light); }
+.copy-status { color: var(--muted); font-size: 0.7rem; }
+.record-facts, .record-evidence {
+  margin: 24px 0 0;
+  padding: 16px 0 0;
+  border-top: 1px solid var(--line);
+}
+.record-modal .record-facts, .record-modal .record-evidence { border-color: var(--line-light); }
+.record-facts dl {
+  display: grid;
+  margin: 12px 0 0;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px 18px;
+}
+.record-facts dt {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.record-facts dd { margin: 3px 0 0; font-size: 0.8rem; overflow-wrap: anywhere; }
+.record-evidence .flag-table { margin-top: 10px; }
+.record-evidence td a { overflow-wrap: anywhere; }
 .hf-card, .config-card {
   margin: 24px 0 0;
   padding: 16px 0 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -393,6 +393,27 @@ code, pre, kbd, .mono-label, .row-status, .topic-total, .pagination { font-famil
   margin: 0 auto;
   padding: 38px 0 64px;
 }
+.detail-page .topic-tabs { margin-bottom: 18px; }
+.related-records {
+  margin: 24px 0 0;
+  padding: 16px 0 0;
+  border-top: 1px solid var(--line);
+}
+.record-modal .related-records { border-color: var(--line-light); }
+.related-records dl { margin: 10px 0 0; }
+.related-records > dl > div { margin: 0 0 12px; }
+.related-records dt {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.related-records dd { margin: 4px 0 0; }
+.related-records ul { margin: 0; padding: 0; list-style: none; }
+.related-records li { margin: 0 0 4px; font-size: 0.8rem; }
+.related-records a { overflow-wrap: anywhere; }
+.related-records p { margin: 6px 0 0; font-size: 0.72rem; }
 .breadcrumbs { display: flex; gap: 7px; margin-bottom: 28px; color: var(--muted); font-family: var(--font-mono); font-size: 0.64rem; }
 .detail-header { padding-bottom: 24px; border-bottom: 1px solid var(--line); }
 .eyebrow { margin-bottom: 8px; color: var(--muted); font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.08em; text-transform: uppercase; }

--- a/app/lib/catalog.ts
+++ b/app/lib/catalog.ts
@@ -77,6 +77,10 @@ export function collectionHref(collection: string): string {
   return topic ? topicHref(topic) : "/"
 }
 
+export function recordHref(collection: string, id: string): string {
+  return `/${collection}/${id}`
+}
+
 export function hrefWithRecord(state: URLSearchParams, id: string): string {
   const selected = new URLSearchParams(state)
   selected.set("record", id)

--- a/app/lib/catalog.ts
+++ b/app/lib/catalog.ts
@@ -1,0 +1,97 @@
+export type Topic = "recipes" | "hardware" | "models" | "prices" | "benchmarks" | "speed-sweeps"
+
+export type TopicSpec = {
+  countKey: string | null
+  description: string
+  key: Topic
+  label: string
+}
+
+export const TOPICS: TopicSpec[] = [
+  { key: "recipes", label: "Recipes", countKey: "recipe", description: "One artifact × hardware × engine unit. Validated rows are launch-safe. Candidate and reference rows are evidence only." },
+  { key: "hardware", label: "Hardware", countKey: "hardware", description: "Accelerator specifications connected to compatible models, recipes, and regional prices." },
+  { key: "models", label: "Models", countKey: "model", description: "Canonical models connected to artifacts, supported hardware, and recipes." },
+  { key: "prices", label: "Prices", countKey: "price", description: "Fresh regional listing observations in native currency. Candidate matches remain inspectable." },
+  { key: "benchmarks", label: "Leaderboards", countKey: "benchmarks", description: "Scraped public quality scores from GitHub Pages leaderboards such as Terminal-Bench 2.1. These are not local speed measurements." },
+  { key: "speed-sweeps", label: "Speed Sweeps", countKey: "speed_sweeps", description: "Measured token/s evidence connected back to the recipe that produced it. These are not public quality leaderboards." },
+]
+
+const COLLECTION_LABELS: Record<string, string> = {
+  hardware: "Hardware",
+  "model-instances": "Model instance",
+  models: "Model",
+  prices: "Regional market price",
+  recipes: "Recipe",
+  benchmarks: "Leaderboard",
+  "speed-sweeps": "Speed sweep",
+}
+
+const COLLECTION_TOPICS: Record<string, Topic> = {
+  hardware: "hardware",
+  "model-instances": "recipes",
+  models: "models",
+  prices: "prices",
+  recipes: "recipes",
+  benchmarks: "benchmarks",
+  "speed-sweeps": "speed-sweeps",
+}
+
+export const TOPIC_FILTERS: Record<Topic, string[]> = {
+  hardware: ["vendor", "backend", "min_vram_gb", "priced_only", "has_recipes"],
+  models: ["family", "architecture"],
+  prices: ["region", "category", "condition", "retailer", "in_stock"],
+  recipes: ["by", "hardware_id", "model_id", "validation", "engine", "runtime", "evidence"],
+  benchmarks: ["category"],
+  "speed-sweeps": ["recipe_id"],
+}
+
+export function isTopic(value: string): value is Topic {
+  return TOPICS.some((topic) => topic.key === value)
+}
+
+export function topicSpec(value: string): TopicSpec | undefined {
+  return TOPICS.find((topic) => topic.key === value)
+}
+
+export function isCollection(value: string): boolean {
+  return value in COLLECTION_LABELS
+}
+
+export function collectionLabel(collection: string): string | undefined {
+  return COLLECTION_LABELS[collection]
+}
+
+export function collectionTopic(collection: string): Topic | undefined {
+  return COLLECTION_TOPICS[collection]
+}
+
+export function topicHref(key: Topic, query = ""): string {
+  const selected = new URLSearchParams()
+  selected.set("topic", key)
+  if (query) selected.set("q", query)
+  return `/?${selected.toString()}`
+}
+
+export function collectionHref(collection: string): string {
+  const topic = collectionTopic(collection)
+  return topic ? topicHref(topic) : "/"
+}
+
+export function hrefWithRecord(state: URLSearchParams, id: string): string {
+  const selected = new URLSearchParams(state)
+  selected.set("record", id)
+  return `/?${selected.toString()}`
+}
+
+export function hrefWithFilter(state: URLSearchParams, name: string, value: string): string {
+  const selected = new URLSearchParams(state)
+  selected.delete("record")
+  selected.delete("offset")
+  selected.set(name, value)
+  return `/?${selected.toString()}`
+}
+
+export function stateHref(state: URLSearchParams): string {
+  const query = state.toString()
+  return query ? `/?${query}` : "/"
+}

--- a/app/lib/record-view.ts
+++ b/app/lib/record-view.ts
@@ -33,7 +33,24 @@ const RELATION_LABELS: Record<string, string> = {
   speed_sweeps: "Speed sweeps",
 }
 
-const TREE_OMIT = new Set(["launch", "huggingface", "relationships"])
+const TREE_OMIT = new Set([
+  "launch",
+  "huggingface",
+  "relationships",
+  "description",
+  "registry",
+])
+
+export type RecordFact = {
+  href?: string
+  label: string
+  value: string
+}
+
+export type CopyItem = {
+  label: string
+  value: string
+}
 
 function nestedName(record: Record<string, unknown>, key: string): string | null {
   const value = record[key]
@@ -101,4 +118,126 @@ export function relatedGroups(record: Record<string, unknown>): RelatedGroup[] {
     })
   }
   return groups
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function fact(label: string, value: unknown, href?: string): RecordFact | null {
+  if (value === null || value === undefined || value === "") return null
+  if (typeof value === "number" && Number.isFinite(value)) return { label, value: value.toLocaleString(), href }
+  if (typeof value === "boolean") return { label, value: value ? "yes" : "no", href }
+  if (typeof value === "string") return { label, value, href }
+  return null
+}
+
+function capabilityFacts(record: Record<string, unknown>): RecordFact[] {
+  const capabilities = asObject(record.capabilities)
+  if (!capabilities) return []
+  return ["chat", "reasoning", "tools", "vision"].flatMap((key) => {
+    const value = capabilities[key]
+    if (value === true) return [{ label: key, value: "yes" }]
+    if (value === false) return [{ label: key, value: "no" }]
+    return [{ label: key, value: "unknown" }]
+  })
+}
+
+export function recordDescription(record: Record<string, unknown>): string | null {
+  return typeof record.description === "string" && record.description.trim() ? record.description : null
+}
+
+export function recordFacts(collection: string, record: Record<string, unknown>): RecordFact[] {
+  const engine = asObject(record.engine)
+  const serving = asObject(record.serving)
+  const memory = asObject(record.memory)
+  const weights = asObject(record.weights)
+  const product = asObject(record.product)
+  const region = asObject(record.region)
+  const summary = asObject(record.summary)
+  if (collection === "recipes") {
+    return [
+      fact("Status", record.status),
+      fact("Source", record.recipe_source),
+      fact("Engine", engine?.name),
+      fact("Engine version", engine?.version),
+      fact("Graph", engine?.graph_mode),
+      fact("Accelerators", record.hardware_count),
+      fact("Tensor parallel", serving?.tensor_parallel),
+      fact("Context tokens", serving?.max_context_tokens),
+      fact("Max concurrency", serving?.max_concurrency),
+      fact("KV cache tokens", serving?.kv_cache_tokens),
+      ...capabilityFacts(record),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "hardware") {
+    return [
+      fact("Vendor", record.vendor),
+      fact("Kind", record.kind),
+      fact("Backend", record.accelerator_backend),
+      fact("VRAM", memory?.vram_gb === undefined ? null : `${memory.vram_gb} GB`),
+      fact("Memory type", memory?.vram_type),
+      fact("Bandwidth", memory?.bandwidth_gb_per_s === undefined ? null : `${memory.bandwidth_gb_per_s} GB/s`),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "models") {
+    return [
+      fact("Family", record.family),
+      fact("Architecture", record.architecture),
+      fact("Parameters", record.params),
+      fact("Active parameters", record.active_params),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "model-instances") {
+    return [
+      fact("Repository", record.repository),
+      fact("Revision", record.revision),
+      fact("Precision", weights?.precision),
+      fact("Format", weights?.format),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "prices") {
+    return [
+      fact("Product", product?.name),
+      fact("Region", region?.name ?? region?.code),
+      fact("Currency", region?.currency),
+      fact("Listings", summary?.listing_count),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "speed-sweeps") {
+    const rows = Array.isArray(record.rows) ? record.rows.length : null
+    return [
+      fact("Recipe", record.recipe_id, typeof record.recipe_id === "string" ? `/recipes/${record.recipe_id}` : undefined),
+      fact("Measured", record.measured_at),
+      fact("Accepted", record.accepted_at),
+      fact("Points", rows),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  if (collection === "benchmarks") {
+    const rows = Array.isArray(record.rows) ? record.rows.length : null
+    return [
+      fact("Category", record.category),
+      fact("Scored models", rows),
+    ].filter((item): item is RecordFact => item !== null)
+  }
+  return []
+}
+
+export function copyItems(collection: string, record: Record<string, unknown>): CopyItem[] {
+  const id = typeof record.id === "string" ? record.id : ""
+  const items: CopyItem[] = []
+  if (id) {
+    items.push({ label: "ID", value: id })
+    items.push({ label: "JSON API", value: `/api/v1/${collection}/${id}` })
+    items.push({ label: "Record URL", value: `/${collection}/${id}` })
+  }
+  const hub = huggingFaceIdentity(record)
+  if (hub?.status === "known" && hub.url) items.push({ label: "Hub repository", value: hub.url })
+  if (typeof record.revision === "string" && record.revision) items.push({ label: "Revision", value: record.revision })
+  if (recipeIsLaunchable(record)) {
+    const launch = asObject(record.launch)
+    const args = Array.isArray(launch?.arguments) ? launch.arguments.filter((item): item is string => typeof item === "string") : []
+    if (args.length > 0) items.push({ label: "Launch arguments", value: args.join(" ") })
+  }
+  return items
 }

--- a/app/lib/record-view.ts
+++ b/app/lib/record-view.ts
@@ -1,0 +1,104 @@
+export type HuggingFaceIdentity = {
+  link_type?: string
+  reason?: string | { code: string; detail: string }
+  repository?: string | null
+  status?: string
+  url?: string
+}
+
+export type RelatedLink = {
+  href: string
+  id: string
+  label: string
+}
+
+export type RelatedGroup = {
+  key: string
+  label: string
+  links: RelatedLink[]
+  moreHref: string | null
+  total: number
+}
+
+const RELATED_CAP = 8
+
+const RELATION_LABELS: Record<string, string> = {
+  hardware: "Hardware",
+  model: "Model",
+  model_instance: "Artifact",
+  model_instances: "Artifacts",
+  prices: "Prices",
+  recipe: "Recipe",
+  recipes: "Recipes",
+  speed_sweeps: "Speed sweeps",
+}
+
+const TREE_OMIT = new Set(["launch", "huggingface", "relationships"])
+
+function nestedName(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  if (value && typeof value === "object" && "name" in value && typeof value.name === "string") return value.name
+  return null
+}
+
+export function recordTitle(detail: Record<string, unknown>, fallback: string): string {
+  if (typeof detail.name === "string" && detail.name) return detail.name
+  if (typeof detail.repository === "string" && detail.repository) return detail.repository
+  return nestedName(detail, "product") ?? nestedName(detail, "model") ?? (typeof detail.id === "string" ? detail.id : fallback)
+}
+
+export function huggingFaceIdentity(record: Record<string, unknown>): HuggingFaceIdentity | null {
+  const value = record.huggingface
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as HuggingFaceIdentity
+}
+
+export function displayRecord(detail: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(detail).filter(([key]) => !TREE_OMIT.has(key)))
+}
+
+export function recipeIsLaunchable(record: Record<string, unknown>): boolean {
+  const registry = record.registry
+  return record.status === "validated"
+    && !!registry
+    && typeof registry === "object"
+    && "launchable" in registry
+    && registry.launchable === true
+}
+
+function isRecordLink(value: unknown): value is { href: string; id: string; name?: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const link = value as { href?: unknown; id?: unknown }
+  return typeof link.href === "string" && typeof link.id === "string"
+}
+
+function moreHrefFor(key: string, record: Record<string, unknown>): string | null {
+  const id = typeof record.id === "string" ? record.id : ""
+  if (key === "recipes" && id) {
+    if (typeof record.vendor === "string" || typeof record.memory === "object") return `/?topic=recipes&hardware_id=${encodeURIComponent(id)}`
+    if (typeof record.family === "string") return `/?topic=recipes&model_id=${encodeURIComponent(id)}`
+  }
+  return null
+}
+
+export function relatedGroups(record: Record<string, unknown>): RelatedGroup[] {
+  const relationships = record.relationships
+  if (!relationships || typeof relationships !== "object" || Array.isArray(relationships)) return []
+  const groups: RelatedGroup[] = []
+  for (const [key, value] of Object.entries(relationships as Record<string, unknown>)) {
+    const items = (Array.isArray(value) ? value : [value]).filter(isRecordLink)
+    if (items.length === 0) continue
+    groups.push({
+      key,
+      label: RELATION_LABELS[key] ?? key.replaceAll("_", " "),
+      links: items.slice(0, RELATED_CAP).map((item) => ({
+        href: item.href,
+        id: item.id,
+        label: item.name || item.id,
+      })),
+      moreHref: items.length > RELATED_CAP ? moreHrefFor(key, record) : null,
+      total: items.length,
+    })
+  }
+  return groups
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,29 +1,39 @@
 import Link from "next/link"
 
-import { DataTree } from "@/app/components/data-tree"
-import { ConfigurationCard, configurationFromRecipe } from "@/app/components/configuration-card"
-import { HuggingFaceCard } from "@/app/components/huggingface-card"
+import {
+  BenchmarkRows,
+  HardwareRows,
+  ModelRows,
+  PriceRows,
+  RecipeRows,
+  SweepRows,
+} from "@/app/components/browse-rows"
+import { CollectionNav } from "@/app/components/collection-nav"
+import { RecordBody } from "@/app/components/record-body"
 import { ModalCloseButton, RecordModal } from "@/app/components/record-modal"
 import { RegistrySearch, type SearchFilter } from "@/app/components/registry-search"
+import {
+  TOPIC_FILTERS,
+  TOPICS,
+  isTopic,
+  stateHref,
+  topicHref,
+  topicSpec,
+  type Topic,
+} from "@/app/lib/catalog"
+import { recordTitle } from "@/app/lib/record-view"
 import {
   collectionCounts,
   getEntityDetail,
   getFacets,
-  getSpeedSweep,
   listHardware,
   listBenchmarks,
   listModels,
   listPrices,
   listSpeedSweeps,
-  marketPriceCount,
   queryCompatibility,
-  recipeCountForHardware,
-  runtimeGroup,
   type CompatibilityFilters,
-  type CompatibilityResult,
-  type PriceResult,
 } from "@/lib/registry"
-import type { SpeedRow, SpeedSweep } from "@/registry/schema/types"
 
 export const dynamic = "force-dynamic"
 
@@ -31,225 +41,20 @@ type PageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
-type Topic = "recipes" | "hardware" | "models" | "prices" | "benchmarks" | "speed-sweeps"
-
-type EvidenceRow = SpeedRow & {
-  sweepId: string
-}
-
-type RowTag = {
-  label: string
-  name: string
-  value: string
-}
-
-const TOPICS: Array<{ key: Topic; label: string; countKey: string | null; description: string }> = [
-  { key: "recipes", label: "Recipes", countKey: "recipe", description: "One artifact × hardware × engine unit. Validated rows are launch-safe. Candidate and reference rows are evidence only." },
-  { key: "hardware", label: "Hardware", countKey: "hardware", description: "Accelerator specifications connected to compatible models, recipes, and regional prices." },
-  { key: "models", label: "Models", countKey: "model", description: "Canonical models connected to artifacts, supported hardware, and recipes." },
-  { key: "prices", label: "Prices", countKey: "price", description: "Fresh regional listing observations in native currency. Candidate matches remain inspectable." },
-  { key: "benchmarks", label: "Leaderboards", countKey: "benchmarks", description: "Scraped public quality scores from GitHub Pages leaderboards such as Terminal-Bench 2.1. These are not local speed measurements." },
-  { key: "speed-sweeps", label: "Speed Sweeps", countKey: "speed_sweeps", description: "Measured token/s evidence connected back to the recipe that produced it. These are not public quality leaderboards." },
-]
-
-const USD_FORMATTER = new Intl.NumberFormat("en-US", {
-  currency: "USD",
-  maximumFractionDigits: 0,
-  style: "currency",
-})
-
-function validTopic(value: string): Topic | "" {
-  return TOPICS.some((topic) => topic.key === value) ? value as Topic : ""
-}
-
-function numberField(record: Record<string, unknown>, key: string): number | null {
-  const value = record[key]
-  return typeof value === "number" && Number.isFinite(value) ? value : null
-}
-
-function formatTokens(value: number | null): string {
-  if (value === null) return "Unknown context"
-  if (value >= 1024) {
-    const thousands = value / 1024
-    return `${Number.isInteger(thousands) ? thousands : thousands.toFixed(1)}K`
-  }
-  return value.toLocaleString()
-}
-
-function formatRate(value: number): string {
-  return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
-}
-
-function formatAmount(amount: number, currency: string): string {
-  return currency === "USD" ? USD_FORMATTER.format(amount) : `${currency} ${amount.toLocaleString()}`
-}
-
-function recipeEvidence(result: CompatibilityResult): EvidenceRow[] {
-  return result.recipe.speed_sweeps_ids.flatMap((sweepId) => {
-    const sweep = getSpeedSweep(sweepId)
-    return sweep ? sweep.rows.map((row) => ({ ...row, sweepId })) : []
-  })
-}
-
-function peakRecipeSpeed(result: CompatibilityResult): number | null {
-  const values = recipeEvidence(result).flatMap((row) => {
-    const value = row.decode_tok_s_per_stream ?? row.decode_tok_s ?? row.prefill_tok_s
-    return typeof value === "number" ? [value] : []
-  })
-  return values.length > 0 ? Math.max(...values) : null
-}
-
-function peakSweepSpeed(sweep: SpeedSweep): number | null {
-  const values = sweep.rows.flatMap((row) => {
-    const value = row.decode_tok_s_per_stream ?? row.decode_tok_s ?? row.prefill_tok_s
-    return typeof value === "number" ? [value] : []
-  })
-  return values.length > 0 ? Math.max(...values) : null
-}
-
-function topicHref(key: Topic, query = ""): string {
-  const selected = new URLSearchParams()
-  selected.set("topic", key)
-  if (query) selected.set("q", query)
-  return `/?${selected.toString()}`
-}
-
-function hrefWithRecord(state: URLSearchParams, id: string): string {
-  const selected = new URLSearchParams(state)
-  selected.set("record", id)
-  return `/?${selected.toString()}`
-}
-
-function hrefWithFilter(state: URLSearchParams, name: string, value: string): string {
-  const selected = new URLSearchParams(state)
-  selected.delete("record")
-  selected.delete("offset")
-  selected.set(name, value)
-  return `/?${selected.toString()}`
-}
-
-function stateHref(state: URLSearchParams): string {
-  const query = state.toString()
-  return query ? `/?${query}` : "/"
-}
-
-function recordTitle(detail: Record<string, unknown>, fallback: string): string {
-  if (typeof detail.name === "string") return detail.name
-  if (typeof detail.repository === "string") return detail.repository
-  const product = detail.product
-  if (product && typeof product === "object" && "name" in product && typeof product.name === "string") return product.name
-  const model = detail.model
-  if (model && typeof model === "object" && "name" in model && typeof model.name === "string") return model.name
-  if (typeof detail.id === "string") return detail.id
-  return fallback
-}
-
 function facetOptions(values: Array<string | number>, allLabel: string, format: (value: string | number) => string = String): SearchFilter["options"] {
   return [{ label: allLabel, value: "" }, ...values.map((value) => ({ label: format(value), value: String(value) }))]
 }
 
-function TaxonomyTags({ state, tags }: { state: URLSearchParams; tags: RowTag[] }) {
-  return (
-    <span className="taxonomy-tags">
-      {tags.slice(0, 4).map((tag) => (
-        <Link aria-label={`Filter by ${tag.label}`} href={hrefWithFilter(state, tag.name, tag.value)} key={`${tag.name}:${tag.value}`}>
-          {tag.label}
-        </Link>
-      ))}
-    </span>
-  )
-}
-
-function RecipeRows({ by, data, state }: { by: "hardware" | "model"; data: CompatibilityResult[]; state: URLSearchParams }) {
-  return (
-    <div className="browser-list recipe-browser-list">
-      {data.map((result) => {
-        const context = numberField(result.recipe.serving, "max_context_tokens")
-        const speed = peakRecipeSpeed(result)
-        const validation = result.launchable ? "validated" : "candidate"
-        const runtime = runtimeGroup(result.recipe.launch.kind)
-        const tags: RowTag[] = [
-          { label: validation, name: "validation", value: validation },
-          { label: result.recipe.engine.name, name: "engine", value: result.recipe.engine.name },
-          { label: runtime === "docker" ? "docker" : runtime === "native" ? "no docker" : "evidence", name: "runtime", value: runtime },
-          { label: result.speed_evidence.available ? "measured" : "unmeasured", name: "evidence", value: String(result.speed_evidence.available) },
-          { label: `${result.hardware.memory.vram_gb} GB+`, name: "min_vram_gb", value: String(result.hardware.memory.vram_gb) },
-        ]
-        return (
-          <article className="browser-row recipe-browser-row" key={result.id}>
-            <Link aria-label={`Open ${result.model.name} recipe`} className="row-open" href={hrefWithRecord(state, result.id)} scroll={false} />
-            <span className={`status-mark ${result.launchable ? "validated" : "candidate"}`} aria-hidden="true" />
-            {by === "hardware" ? (
-              <>
-                <span className="row-primary"><strong>{result.hardware.name}</strong><small>{result.recipe.hardware_count} × {result.hardware.memory.vram_gb} GB</small></span>
-                <span><strong>{result.model.name}</strong><small>{result.model_instance.weights.precision ?? result.model_instance.weights.format ?? "Unknown precision"}</small></span>
-              </>
-            ) : (
-              <>
-                <span className="row-primary"><strong>{result.model.name}</strong><small>{result.model_instance.weights.precision ?? result.model_instance.weights.format ?? "Unknown precision"}</small></span>
-                <span><strong>{result.hardware.name}</strong><small>{result.recipe.hardware_count} × {result.hardware.memory.vram_gb} GB</small></span>
-              </>
-            )}
-            <span><strong>{result.recipe.engine.name}</strong><small>{result.recipe.launch.kind}</small></span>
-            <span><strong>{formatTokens(context)}</strong><small>context</small></span>
-            <span><strong>{speed === null ? "—" : `${formatRate(speed)} tok/s`}</strong><small>{result.speed_evidence.available ? "measured" : "no evidence"}</small></span>
-            <TaxonomyTags state={state} tags={tags} />
-            <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-          </article>
-        )
-      })}
-    </div>
-  )
-}
-
-function PriceRows({ data, state }: { data: PriceResult[]; state: URLSearchParams }) {
-  return (
-    <div className="browser-list collection-list">
-      {data.map((record) => {
-        const amount = record.summary.lowest_new ?? record.summary.lowest_refurbished ?? record.summary.lowest_used
-        const condition = record.summary.lowest_new !== null
-          ? "new"
-          : record.summary.lowest_refurbished !== null ? "refurbished" : record.summary.lowest_used !== null ? "used" : "unavailable"
-        const tags: RowTag[] = [
-          { label: record.region.code, name: "region", value: record.region.code },
-          { label: record.product.category, name: "category", value: record.product.category },
-          { label: condition, name: "condition", value: condition },
-        ]
-        return (
-          <article className="browser-row price-row" key={record.id}>
-            <Link aria-label={`Open ${record.product.name} market observations`} className="row-open" href={hrefWithRecord(state, record.id)} scroll={false} />
-            <span className="row-primary"><strong>{record.product.name}</strong><small>{record.product.id}</small></span>
-            <span><strong>{amount === null ? "No available listing" : formatAmount(amount, record.region.currency)}</strong><small>lowest available · {condition}</small></span>
-            <span><strong>{record.region.name}</strong><small>{record.region.currency}</small></span>
-            <span><strong>{record.observed_at.slice(0, 10)}</strong><small>observed</small></span>
-            <span><strong>{record.summary.listing_count} listings</strong><small>{record.summary.retailer_count} retailers</small></span>
-            <TaxonomyTags state={state} tags={tags} />
-            <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-          </article>
-        )
-      })}
-    </div>
-  )
-}
-
-function displayRecord(detail: Record<string, unknown>): Record<string, unknown> {
-  const { launch: _launch, huggingface: _huggingface, ...rest } = detail
-  return rest
-}
-
-function recordHuggingFace(detail: Record<string, unknown>): Record<string, unknown> | null {
-  const value = detail.huggingface
-  return value && typeof value === "object" ? value as Record<string, unknown> : null
+function param(params: Record<string, string | string[] | undefined>, key: string): string {
+  const selected = params[key]
+  return Array.isArray(selected) ? selected[0] : selected ?? ""
 }
 
 export default async function Home({ searchParams }: PageProps) {
   const params = await searchParams
-  const value = (key: string) => {
-    const selected = params[key]
-    return Array.isArray(selected) ? selected[0] : selected ?? ""
-  }
-
-  const topic = validTopic(value("topic"))
+  const value = (key: string) => param(params, key)
+  const topicValue = value("topic")
+  const topic: Topic | "" = isTopic(topicValue) ? topicValue : ""
   const query = value("q")
   const validation = value("validation")
   const recipeBrowse = value("by") === "model" ? "model" : "hardware"
@@ -258,6 +63,7 @@ export default async function Home({ searchParams }: PageProps) {
   const pagination = { limit, offset }
   const facets = getFacets()
   const counts = collectionCounts()
+  const spec = topic ? topicSpec(topic) : undefined
 
   const recipeFilters: CompatibilityFilters = {
     engine: value("engine"),
@@ -307,39 +113,28 @@ export default async function Home({ searchParams }: PageProps) {
       }
     : null
 
-  const filterKeys: Partial<Record<Topic, string[]>> = {
-    hardware: ["vendor", "backend", "min_vram_gb", "priced_only", "has_recipes"],
-    models: ["family", "architecture"],
-    prices: ["region", "category", "condition", "retailer", "in_stock"],
-    recipes: ["by", "hardware_id", "model_id", "validation", "engine", "runtime", "evidence"],
-    benchmarks: ["category"],
-    "speed-sweeps": ["recipe_id"],
-  }
   const viewState = new URLSearchParams()
   if (topic) viewState.set("topic", topic)
   if (topic === "recipes") viewState.set("by", recipeBrowse)
   if (query) viewState.set("q", query)
-  for (const key of topic ? filterKeys[topic] ?? [] : []) {
+  for (const key of topic ? TOPIC_FILTERS[topic] : []) {
     const selected = value(key)
     if (selected) viewState.set(key, selected)
   }
   if (offset > 0) viewState.set("offset", String(offset))
 
-  const detailCollection = topic
-  const selectedRecord = detailCollection && value("record") ? getEntityDetail(detailCollection, value("record")) : undefined
+  const selectedId = value("record")
+  const selectedRecord = topic && selectedId ? getEntityDetail(topic, selectedId) : undefined
   const closeHref = stateHref(viewState)
-  const selectedTitle = selectedRecord ? recordTitle(selectedRecord, value("record")) : ""
-  const total = topic === "recipes"
-    ? recipeResults.total
-    : topic === "hardware"
-      ? hardwareResults.total
-      : topic === "models"
-        ? modelResults.total
-        : topic === "prices"
-          ? priceResults.total
-          : topic === "benchmarks" ? benchmarkResults.total : topic === "speed-sweeps" ? sweepResults.total : 0
-  const topicLabel = TOPICS.find((item) => item.key === topic)?.label
-  const topicDescription = TOPICS.find((item) => item.key === topic)?.description
+  const totals: Record<Topic, number> = {
+    recipes: recipeResults.total,
+    hardware: hardwareResults.total,
+    models: modelResults.total,
+    prices: priceResults.total,
+    benchmarks: benchmarkResults.total,
+    "speed-sweeps": sweepResults.total,
+  }
+  const total = topic ? totals[topic] : 0
 
   const pageState = new URLSearchParams(viewState)
   pageState.delete("offset")
@@ -362,46 +157,36 @@ export default async function Home({ searchParams }: PageProps) {
     ] },
     { label: "Evidence", name: "evidence", value: value("evidence"), options: facetOptions(["true", "false"], "Any evidence", (item) => item === "true" ? "Measured speed attached" : "No measured speed") },
   ]
-  const hardwareSearchFilters: SearchFilter[] = [
-    { label: "Vendor", name: "vendor", value: value("vendor"), options: facetOptions(facets.hardware.vendor, "Any vendor") },
-    { label: "Backend", name: "backend", value: value("backend"), options: facetOptions(facets.hardware.backend, "Any backend") },
-    { label: "Memory", name: "min_vram_gb", value: value("min_vram_gb"), options: facetOptions(facets.hardware.vram_gb, "Any memory", (item) => `At least ${item} GB`) },
-    { label: "Pricing", name: "priced_only", value: value("priced_only"), options: facetOptions(["true"], "All hardware", () => "Priced only") },
-    { label: "Recipes", name: "has_recipes", value: value("has_recipes"), options: facetOptions(["true", "false"], "All hardware", (item) => item === "true" ? "Has recipes" : "No recipes yet") },
-  ]
-  const modelSearchFilters: SearchFilter[] = [
-    { label: "Family", name: "family", value: value("family"), options: facetOptions(facets.models.family, "Any family") },
-    { label: "Architecture", name: "architecture", value: value("architecture"), options: facetOptions(facets.models.architecture, "Any architecture") },
-  ]
-  const priceSearchFilters: SearchFilter[] = [
-    { label: "Region", name: "region", value: value("region"), options: facetOptions(facets.prices.region, "Any region") },
-    { label: "Category", name: "category", value: value("category"), options: facetOptions(facets.prices.category, "Any category") },
-    { label: "Condition", name: "condition", value: value("condition"), options: facetOptions(facets.prices.condition, "Any condition") },
-    { label: "Retailer", name: "retailer", value: value("retailer"), options: facetOptions(facets.prices.retailer, "Any retailer") },
-    { label: "Availability", name: "in_stock", value: value("in_stock"), options: facetOptions(["true", "false", "unknown"], "Any availability", (item) => item === "true" ? "In stock" : item === "false" ? "Out of stock" : "Unknown stock") },
-  ]
-  const benchmarkSearchFilters: SearchFilter[] = [
-    { label: "Category", name: "category", value: value("category"), options: facetOptions(facets.benchmarks.category, "Any category") },
-  ]
   const topicFilters = topic === "recipes"
     ? recipeSearchFilters
     : topic === "hardware"
-      ? hardwareSearchFilters
+      ? [
+          { label: "Vendor", name: "vendor", value: value("vendor"), options: facetOptions(facets.hardware.vendor, "Any vendor") },
+          { label: "Backend", name: "backend", value: value("backend"), options: facetOptions(facets.hardware.backend, "Any backend") },
+          { label: "Memory", name: "min_vram_gb", value: value("min_vram_gb"), options: facetOptions(facets.hardware.vram_gb, "Any memory", (item) => `At least ${item} GB`) },
+          { label: "Pricing", name: "priced_only", value: value("priced_only"), options: facetOptions(["true"], "All hardware", () => "Priced only") },
+          { label: "Recipes", name: "has_recipes", value: value("has_recipes"), options: facetOptions(["true", "false"], "All hardware", (item) => item === "true" ? "Has recipes" : "No recipes yet") },
+        ]
       : topic === "models"
-        ? modelSearchFilters
+        ? [
+            { label: "Family", name: "family", value: value("family"), options: facetOptions(facets.models.family, "Any family") },
+            { label: "Architecture", name: "architecture", value: value("architecture"), options: facetOptions(facets.models.architecture, "Any architecture") },
+          ]
         : topic === "prices"
-          ? priceSearchFilters
+          ? [
+              { label: "Region", name: "region", value: value("region"), options: facetOptions(facets.prices.region, "Any region") },
+              { label: "Category", name: "category", value: value("category"), options: facetOptions(facets.prices.category, "Any category") },
+              { label: "Condition", name: "condition", value: value("condition"), options: facetOptions(facets.prices.condition, "Any condition") },
+              { label: "Retailer", name: "retailer", value: value("retailer"), options: facetOptions(facets.prices.retailer, "Any retailer") },
+              { label: "Availability", name: "in_stock", value: value("in_stock"), options: facetOptions(["true", "false", "unknown"], "Any availability", (item) => item === "true" ? "In stock" : item === "false" ? "Out of stock" : "Unknown stock") },
+            ]
           : topic === "benchmarks"
-            ? benchmarkSearchFilters
+            ? [{ label: "Category", name: "category", value: value("category"), options: facetOptions(facets.benchmarks.category, "Any category") }]
             : []
 
   return (
     <main className="registry-main">
-      <nav aria-label="Registry collections" className="topic-tabs">
-        {TOPICS.map((item) => (
-          <Link aria-current={topic === item.key ? "page" : undefined} href={topicHref(item.key, query)} key={item.key}>{item.label}</Link>
-        ))}
-      </nav>
+      <CollectionNav current={topic} query={query} />
 
       {!topic ? (
         <>
@@ -430,104 +215,17 @@ export default async function Home({ searchParams }: PageProps) {
         </>
       ) : (
         <>
-          <header className="topic-heading"><div><span className="mono-label">COLLECTION / {topic.toUpperCase()}</span><h1>{topicLabel}</h1><p className="topic-description">{topicDescription}</p></div><span className="topic-total">{total.toLocaleString()} records</span></header>
-          <section className="topic-search" aria-label={`${topicLabel} search`}><RegistrySearch filters={topicFilters} query={query} topic={topic} /></section>
-
+          <header className="topic-heading"><div><span className="mono-label">COLLECTION / {topic.toUpperCase()}</span><h1>{spec?.label}</h1><p className="topic-description">{spec?.description}</p></div><span className="topic-total">{total.toLocaleString()} records</span></header>
+          <section className="topic-search" aria-label={`${spec?.label} search`}><RegistrySearch filters={topicFilters} query={query} topic={topic} /></section>
           {topic === "recipes" && <RecipeRows by={recipeBrowse} data={recipeResults.data} state={viewState} />}
-          {topic === "hardware" && (
-            <div className="browser-list collection-list">
-              {hardwareResults.data.map((hardware) => {
-                const hasPrices = marketPriceCount(hardware.id) > 0
-                const recipes = recipeCountForHardware(hardware.id)
-                const tags: RowTag[] = [
-                  { label: hardware.vendor, name: "vendor", value: hardware.vendor },
-                  { label: hardware.accelerator_backend, name: "backend", value: hardware.accelerator_backend },
-                  { label: `${hardware.memory.vram_gb} GB+`, name: "min_vram_gb", value: String(hardware.memory.vram_gb) },
-                  ...(hasPrices ? [{ label: "priced", name: "priced_only", value: "true" }] : []),
-                  { label: recipes > 0 ? `${recipes} recipes` : "no recipes", name: "has_recipes", value: recipes > 0 ? "true" : "false" },
-                ]
-                return (
-                  <article className="browser-row collection-row" key={hardware.id}>
-                    <Link aria-label={`Open ${hardware.name}`} className="row-open" href={hrefWithRecord(viewState, hardware.id)} scroll={false} />
-                    <span className="row-primary"><strong>{hardware.name}</strong><small>{hardware.id}</small></span>
-                    <span><strong>{hardware.vendor}</strong><small>{hardware.kind}</small></span>
-                    <span><strong>{hardware.memory.vram_gb} GB</strong><small>{hardware.memory.vram_type ?? "Memory type unknown"}</small></span>
-                    <span><strong>{recipes.toLocaleString()}</strong><small>{recipes === 1 ? "recipe" : "recipes"}</small></span>
-                    <TaxonomyTags state={viewState} tags={tags} />
-                    <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-                  </article>
-                )
-              })}
-            </div>
-          )}
-          {topic === "models" && (
-            <div className="browser-list collection-list">
-              {modelResults.data.map((model) => {
-                const tags: RowTag[] = [
-                  { label: model.family, name: "family", value: model.family },
-                  { label: model.architecture ?? "unknown", name: "architecture", value: model.architecture ?? "unknown" },
-                ]
-                return (
-                  <article className="browser-row collection-row" key={model.id}>
-                    <Link aria-label={`Open ${model.name}`} className="row-open" href={hrefWithRecord(viewState, model.id)} scroll={false} />
-                    <span className="row-primary"><strong>{model.name}</strong><small>{model.id}</small></span>
-                    <span><strong>{model.family}</strong><small>family</small></span>
-                    <span><strong>{model.architecture ?? "Unknown"}</strong><small>architecture</small></span>
-                    <span><strong>{model.params ?? "—"}</strong><small>parameters</small></span>
-                    <TaxonomyTags state={viewState} tags={tags} />
-                    <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-                  </article>
-                )
-              })}
-            </div>
-          )}
+          {topic === "hardware" && <HardwareRows data={hardwareResults.data} state={viewState} />}
+          {topic === "models" && <ModelRows data={modelResults.data} state={viewState} />}
           {topic === "prices" && <PriceRows data={priceResults.data} state={viewState} />}
-          {topic === "benchmarks" && (
-            <div className="browser-list collection-list">
-              {benchmarkResults.data.map((benchmark) => {
-                const top = benchmark.rows[0]
-                const tags: RowTag[] = [
-                  ...(benchmark.category ? [{ label: benchmark.category, name: "category", value: benchmark.category }] : []),
-                ]
-                return (
-                  <article className="browser-row collection-row" key={benchmark.id}>
-                    <Link aria-label={`Open ${benchmark.id}`} className="row-open" href={hrefWithRecord(viewState, benchmark.id)} scroll={false} />
-                    <span className="row-primary"><strong>{benchmark.name}</strong><small>{benchmark.id}</small></span>
-                    <span><strong>{benchmark.category ?? "Unknown"}</strong><small>category</small></span>
-                    <span><strong>{benchmark.rows.length}</strong><small>scored models</small></span>
-                    <span><strong>{top ? (top.score === null ? "—" : formatRate(top.score)) : "—"}</strong><small>top score</small></span>
-                    <TaxonomyTags state={viewState} tags={tags} />
-                    <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-                  </article>
-                )
-              })}
-            </div>
-          )}
-          {topic === "speed-sweeps" && (
-            <div className="browser-list collection-list">
-              {sweepResults.data.map((sweep) => {
-                const speed = peakSweepSpeed(sweep)
-                const tags: RowTag[] = [
-                  { label: sweep.recipe_id, name: "recipe_id", value: sweep.recipe_id },
-                ]
-                return (
-                  <article className="browser-row collection-row" key={sweep.id}>
-                    <Link aria-label={`Open ${sweep.id}`} className="row-open" href={hrefWithRecord(viewState, sweep.id)} scroll={false} />
-                    <span className="row-primary"><strong>{sweep.id}</strong><small>{sweep.recipe_id}</small></span>
-                    <span><strong>{sweep.measured_at ?? "Unknown"}</strong><small>measured</small></span>
-                    <span><strong>{sweep.rows.length}</strong><small>points</small></span>
-                    <span><strong>{speed === null ? "—" : `${formatRate(speed)} tok/s`}</strong><small>peak recorded</small></span>
-                    <TaxonomyTags state={viewState} tags={tags} />
-                    <svg aria-hidden="true" className="row-arrow" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6" /></svg>
-                  </article>
-                )
-              })}
-            </div>
-          )}
-
+          {topic === "benchmarks" && <BenchmarkRows data={benchmarkResults.data} state={viewState} />}
+          {topic === "speed-sweeps" && <SweepRows data={sweepResults.data} state={viewState} />}
           {total === 0 && <div className="empty-state"><h2>No records found.</h2><p>Clear the search or remove a filter.</p></div>}
           {(offset > 0 || offset + limit < total) && (
-            <nav aria-label={`${topicLabel} pages`} className="pagination">
+            <nav aria-label={`${spec?.label} pages`} className="pagination">
               {offset > 0 ? <Link href={stateHref(previousState)}>Previous</Link> : <span />}
               <span>{offset + 1}–{Math.min(offset + limit, total)} of {total}</span>
               {offset + limit < total ? <Link href={stateHref(nextState)}>Next</Link> : <span />}
@@ -536,29 +234,18 @@ export default async function Home({ searchParams }: PageProps) {
         </>
       )}
 
-      {selectedRecord && detailCollection && (
+      {selectedRecord && topic && (
         <RecordModal closeHref={closeHref} titleId="record-modal-title">
           <header className="record-modal-header">
-            <div><span className="mono-label">{detailCollection.toUpperCase()} / RECORD</span><h2 id="record-modal-title">{selectedTitle}</h2><code>{value("record")}</code></div>
+            <div><span className="mono-label">{topic.toUpperCase()} / RECORD</span><h2 id="record-modal-title">{recordTitle(selectedRecord, selectedId)}</h2><code>{selectedId}</code></div>
             <ModalCloseButton className="modal-close" closeHref={closeHref} label="Close record details">Close</ModalCloseButton>
           </header>
           <div className="record-modal-body">
-            <HuggingFaceCard identity={recordHuggingFace(selectedRecord) as { link_type?: string; reason?: string; repository?: string | null; status?: string; url?: string } | null} />
-            {detailCollection === "recipes" && (
-              <>
-                <p className="trust-note">
-                  {selectedRecord.status === "validated" && selectedRecord.registry && typeof selectedRecord.registry === "object" && "launchable" in selectedRecord.registry && selectedRecord.registry.launchable
-                    ? "Validated: pinned artifact, pinned runtime, and accepted evidence. This is a launch contract."
-                    : "Candidate: useful compatibility or speed evidence. The registry does not offer Run until promotion requirements are met."}
-                </p>
-                <ConfigurationCard config={configurationFromRecipe(selectedRecord, typeof selectedRecord.engine === "object" && selectedRecord.engine && "name" in selectedRecord.engine ? String((selectedRecord.engine as { name?: string }).name) : undefined)} />
-              </>
-            )}
-            <DataTree value={displayRecord(selectedRecord)} />
+            <RecordBody collection={topic} record={selectedRecord} variant="overlay" />
           </div>
           <footer className="record-modal-footer">
-            <a href={`/api/v1/${detailCollection}/${value("record")}`}>JSON API</a>
-            <Link href={`/${detailCollection}/${value("record")}`}>Permanent record URL</Link>
+            <a href={`/api/v1/${topic}/${selectedId}`}>JSON API</a>
+            <Link href={`/${topic}/${selectedId}`}>Permanent record URL</Link>
           </footer>
         </RecordModal>
       )}

--- a/test/record-view.test.ts
+++ b/test/record-view.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { collectionHref, collectionLabel, collectionTopic, isCollection, isTopic, topicHref } from "../app/lib/catalog"
+import { displayRecord, recordTitle, relatedGroups, recipeIsLaunchable } from "../app/lib/record-view"
+import { getEntityDetail } from "../lib/registry"
+
+test("collection catalog maps path segments onto browse topics", () => {
+  assert.equal(isTopic("recipes"), true)
+  assert.equal(isTopic("model-instances"), false)
+  assert.equal(isCollection("model-instances"), true)
+  assert.equal(collectionLabel("recipes"), "Recipe")
+  assert.equal(collectionTopic("model-instances"), "recipes")
+  assert.equal(topicHref("hardware", "rtx"), "/?topic=hardware&q=rtx")
+  assert.equal(collectionHref("prices"), "/?topic=prices")
+})
+
+test("record title and display tree hide contract fields already shown as cards", () => {
+  const recipe = getEntityDetail("recipes", "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1") as Record<string, unknown>
+  assert.equal(recordTitle(recipe, "fallback"), recipe.id)
+  const tree = displayRecord(recipe)
+  assert.ok(!("launch" in tree))
+  assert.ok(!("huggingface" in tree))
+  assert.ok(!("relationships" in tree))
+  assert.equal(recipeIsLaunchable(recipe), true)
+})
+
+test("related records expose permanent hrefs instead of burying them in the tree", () => {
+  const recipe = getEntityDetail("recipes", "acereason-nemotron-1-1-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1") as Record<string, unknown>
+  const groups = relatedGroups(recipe)
+  const hardware = groups.find((group) => group.key === "hardware")
+  const model = groups.find((group) => group.key === "model")
+  assert.ok(hardware)
+  assert.equal(hardware.links[0]?.href, "/hardware/rtx-3060-ti-8gb")
+  assert.ok(model)
+  assert.match(model.links[0]?.href ?? "", /^\/models\//)
+  assert.equal(recipeIsLaunchable(recipe), false)
+})
+
+test("long relationship lists cap and offer a collection search", () => {
+  const model = getEntityDetail("models", "gemma-4-12b-it") as Record<string, unknown>
+  const groups = relatedGroups(model)
+  const recipes = groups.find((group) => group.key === "recipes")
+  assert.ok(recipes)
+  assert.ok(recipes.total >= recipes.links.length)
+  if (recipes.total > 8) {
+    assert.equal(recipes.links.length, 8)
+    assert.equal(recipes.moreHref, "/?topic=recipes&model_id=gemma-4-12b-it")
+  }
+})

--- a/test/record-view.test.ts
+++ b/test/record-view.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { collectionHref, collectionLabel, collectionTopic, isCollection, isTopic, topicHref } from "../app/lib/catalog"
-import { displayRecord, recordTitle, relatedGroups, recipeIsLaunchable } from "../app/lib/record-view"
+import { collectionHref, collectionLabel, collectionTopic, isCollection, isTopic, recordHref, topicHref } from "../app/lib/catalog"
+import { copyItems, displayRecord, recordFacts, recordTitle, relatedGroups, recipeIsLaunchable } from "../app/lib/record-view"
 import { getEntityDetail } from "../lib/registry"
 
 test("collection catalog maps path segments onto browse topics", () => {
@@ -13,6 +13,7 @@ test("collection catalog maps path segments onto browse topics", () => {
   assert.equal(collectionTopic("model-instances"), "recipes")
   assert.equal(topicHref("hardware", "rtx"), "/?topic=hardware&q=rtx")
   assert.equal(collectionHref("prices"), "/?topic=prices")
+  assert.equal(recordHref("recipes", "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1"), "/recipes/gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1")
 })
 
 test("record title and display tree hide contract fields already shown as cards", () => {
@@ -47,4 +48,15 @@ test("long relationship lists cap and offer a collection search", () => {
     assert.equal(recipes.links.length, 8)
     assert.equal(recipes.moreHref, "/?topic=recipes&model_id=gemma-4-12b-it")
   }
+})
+
+test("detail facts and copy items come from the record, not a shell dump", () => {
+  const recipe = getEntityDetail("recipes", "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1") as Record<string, unknown>
+  const facts = recordFacts("recipes", recipe)
+  assert.ok(facts.some((item) => item.label === "Status" && item.value === "validated"))
+  assert.ok(facts.some((item) => item.label === "Engine" && item.value === "sglang"))
+  const copies = copyItems("recipes", recipe)
+  assert.ok(copies.some((item) => item.label === "Launch arguments" && item.value.includes("-lc")))
+  const candidate = getEntityDetail("recipes", "acereason-nemotron-1-1-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1") as Record<string, unknown>
+  assert.equal(copyItems("recipes", candidate).some((item) => item.label === "Launch arguments"), false)
 })


### PR DESCRIPTION
The model/hardware detail-page work (`cursor/registry-nav-components-dc5e`: permanent detail pages, shared record body, collection catalog, related-record nav, browse-row cards, copy actions, evidence/facts panels — 1,087 lines) was built against the pre-overhaul main and **never merged**; the deployed site never had it. This merges it onto today's registry model: singular collection names, sharded index, HF-downloads sort (the downloads column now lives in the new `ModelRows` card). 37/37 tests green including the branch's record-view suite; build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)