### PR TITLE
Remove accidentally committed .claude session cache

### DIFF
--- a/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/affected-repos.txt
+++ b/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/affected-repos.txt
@@ -1,2 +1,0 @@
-root
-app

--- a/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/edited-files.log
+++ b/.claude/tsc-cache/84c44778-38c3-44f2-b2a8-e2cb08a37ac9/edited-files.log
@@ -1,3 +1,0 @@
-1788174978:/Users/sero/local-registry/local-ai-registry/Makefile:root
-1788175192:/Users/sero/local-registry/local-ai-registry/app/page.tsx:app
-1788179834:/Users/sero/local-registry/local-ai-registry/app/page.tsx:app

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ out/
 coverage/
 __pycache__/
 *.pyc
+
+.claude/


### PR DESCRIPTION
Two earlier commits swept local `.claude/tsc-cache/` session files into the repo via `git add -A`. Removes them and gitignores `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)