### PR TITLE
Model pages: leaderboard scores + downloads (completes T24)

### DIFF
--- a/app/components/model-scores.tsx
+++ b/app/components/model-scores.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+
+import { getModelBenchmarkScores } from "@/lib/registry"
+
+export function ModelScores({ modelId }: { modelId: string }) {
+  const scores = getModelBenchmarkScores(modelId)
+  if (scores.length === 0) return null
+  const rows = [...scores].sort(
+    (left, right) =>
+      (left.category ?? "").localeCompare(right.category ?? "") ||
+      left.benchmark_id.localeCompare(right.benchmark_id),
+  )
+  return (
+    <section aria-label="Public leaderboard scores" className="record-evidence">
+      <p className="eyebrow">Leaderboard scores</p>
+      <p className="trust-note">
+        Scraped public quality scores joined to this model by its Hugging Face repository. They describe the listed
+        variant, not any specific local quantization, and are never speed measurements.
+      </p>
+      <table className="flag-table">
+        <thead>
+          <tr>
+            <th>Benchmark</th>
+            <th>Category</th>
+            <th>Score</th>
+            <th>Rank</th>
+            <th>Scored variant</th>
+            <th>Confidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={`${row.benchmark_id}-${index}`}>
+              <td><Link href={`/benchmark/${row.benchmark_id}`}>{row.benchmark_id}</Link></td>
+              <td>{row.category ?? "—"}</td>
+              <td>{row.score ?? "—"}</td>
+              <td>{row.rank ?? "—"}</td>
+              <td>{row.variant ?? "—"}</td>
+              <td>{row.conf ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/app/components/record-body.tsx
+++ b/app/components/record-body.tsx
@@ -2,6 +2,7 @@ import { ConfigurationCard, configurationFromRecipe } from "@/app/components/con
 import { CopyActions } from "@/app/components/copy-actions"
 import { DataTree } from "@/app/components/data-tree"
 import { HuggingFaceCard } from "@/app/components/huggingface-card"
+import { ModelScores } from "@/app/components/model-scores"
 import { RecordEvidence } from "@/app/components/record-evidence"
 import { RecordFacts } from "@/app/components/record-facts"
 import { RelatedRecords } from "@/app/components/related-records"
@@ -48,6 +49,7 @@ export function RecordBody({
         </>
       )}
       <RecordEvidence collection={collection} record={record} />
+      {collection === "models" && typeof record.id === "string" && <ModelScores modelId={record.id} />}
       <RelatedRecords groups={groups} />
       {variant === "page" ? (
         <section className="record-sheet">

--- a/app/lib/record-view.ts
+++ b/app/lib/record-view.ts
@@ -181,11 +181,14 @@ export function recordFacts(collection: string, record: Record<string, unknown>)
     ].filter((item): item is RecordFact => item !== null)
   }
   if (collection === "models") {
+    const downloads = asObject(record.downloads)
+    const monthly = typeof downloads?.last_30d === "number" ? downloads.last_30d.toLocaleString("en-US") : null
     return [
       fact("Family", record.family),
       fact("Architecture", record.architecture),
       fact("Parameters", record.params),
       fact("Active parameters", record.active_params),
+      fact("HF downloads / 30d", monthly),
     ].filter((item): item is RecordFact => item !== null)
   }
   if (collection === "model-instances") {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -202,6 +202,27 @@ export function getSpeedSweep(id: string): SpeedSweep | undefined {
   return readRecord("speed-sweep", id)
 }
 
+export type ModelBenchmarkScore = {
+  benchmark_id: string
+  category: string | null
+  rank: number | null
+  score: number | null
+  variant: string | null
+  conf: string | null
+}
+
+let cachedScores: Record<string, ModelBenchmarkScore[]> | undefined
+
+export function getModelBenchmarkScores(modelId: string): ModelBenchmarkScore[] {
+  if (!cachedScores) {
+    cachedScores = readJson<{ benchmarks_by_model: Record<string, ModelBenchmarkScore[]> }>(
+      "index",
+      "benchmarks-by-model.json",
+    ).benchmarks_by_model
+  }
+  return cachedScores[modelId] ?? []
+}
+
 export function getBenchmark(id: string): Benchmark | undefined {
   return dataset().benchmarks.get(id)
 }


### PR DESCRIPTION
Model detail pages render a **Leaderboard scores** table from the `benchmarks-by-model` shard (benchmark → category → score → rank → scored variant → confidence, each linking to the leaderboard record), with a trust note that scores describe the listed variant, never a local quantization or speed. The RECORD strip shows 30-day HF downloads. Hardware pages already surface related prices/models/recipes via the restored UI — this closes the last visible join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)