### PR TITLE
Fold speed sweeps into recipes

### DIFF
--- a/app/components/browse-rows.tsx
+++ b/app/components/browse-rows.tsx
@@ -273,31 +273,3 @@ export function BenchmarkRows({ data, state }: { data: Benchmark[]; state: URLSe
     </div>
   )
 }
-
-export function SweepRows({ data, state }: { data: SpeedSweep[]; state: URLSearchParams }) {
-  return (
-    <div className="browser-list collection-list">
-      {data.map((sweep) => {
-        const speed = peakSpeed(sweep.rows)
-        const tags: RowTag[] = [
-          { label: sweep.recipe_id, name: "recipe_id", value: sweep.recipe_id },
-        ]
-        return (
-          <BrowserRow
-            className="collection-row"
-            href={recordHref("speed-sweep", sweep.id)}
-            key={sweep.id}
-            label={`Open ${sweep.id}`}
-            state={state}
-            tags={tags}
-          >
-            <span className="row-primary"><strong>{sweep.id}</strong><small>{sweep.recipe_id}</small></span>
-            <span><strong>{sweep.measured_at ?? "Unknown"}</strong><small>measured</small></span>
-            <span><strong>{sweep.rows.length}</strong><small>points</small></span>
-            <span><strong>{speed === null ? "—" : `${formatRate(speed)} tok/s`}</strong><small>peak recorded</small></span>
-          </BrowserRow>
-        )
-      })}
-    </div>
-  )
-}

--- a/app/lib/catalog.ts
+++ b/app/lib/catalog.ts
@@ -1,4 +1,4 @@
-export type Topic = "recipes" | "hardware" | "models" | "prices" | "benchmark" | "speed-sweep"
+export type Topic = "recipes" | "hardware" | "models" | "prices" | "benchmark"
 
 export type TopicSpec = {
   countKey: string | null
@@ -8,12 +8,11 @@ export type TopicSpec = {
 }
 
 export const TOPICS: TopicSpec[] = [
-  { key: "recipes", label: "Recipes", countKey: "recipe", description: "One artifact × hardware × engine unit. Validated rows are launch-safe. Candidate and reference rows are evidence only." },
+  { key: "recipes", label: "Recipes", countKey: "recipe", description: "One artifact × hardware × engine unit. Validated rows are launch-safe; measured speed sweeps attach to each recipe as evidence." },
   { key: "hardware", label: "Hardware", countKey: "hardware", description: "Accelerator specifications connected to compatible models, recipes, and regional prices." },
   { key: "models", label: "Models", countKey: "model", description: "Canonical models connected to artifacts, supported hardware, and recipes." },
   { key: "prices", label: "Prices", countKey: "price", description: "Fresh regional listing observations in native currency. Candidate matches remain inspectable." },
   { key: "benchmark", label: "Leaderboards", countKey: "benchmark", description: "Scraped public quality scores from GitHub Pages leaderboards such as Terminal-Bench 2.1. These are not local speed measurements." },
-  { key: "speed-sweep", label: "Speed Sweeps", countKey: "speed_sweep", description: "Measured token/s evidence connected back to the recipe that produced it. These are not public quality leaderboards." },
 ]
 
 const COLLECTION_LABELS: Record<string, string> = {
@@ -33,7 +32,7 @@ const COLLECTION_TOPICS: Record<string, Topic> = {
   prices: "prices",
   recipes: "recipes",
   benchmark: "benchmark",
-  "speed-sweep": "speed-sweep",
+  "speed-sweep": "recipes",
 }
 
 export const TOPIC_FILTERS: Record<Topic, string[]> = {
@@ -42,7 +41,6 @@ export const TOPIC_FILTERS: Record<Topic, string[]> = {
   prices: ["region", "category", "condition", "retailer", "in_stock"],
   recipes: ["by", "hardware_id", "model_id", "validation", "engine", "runtime", "evidence"],
   benchmark: ["category"],
-  "speed-sweep": ["recipe_id"],
 }
 
 export function isTopic(value: string): value is Topic {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,6 @@ import {
   ModelRows,
   PriceRows,
   RecipeRows,
-  SweepRows,
 } from "@/app/components/browse-rows"
 import { CollectionNav } from "@/app/components/collection-nav"
 import { RecordBody } from "@/app/components/record-body"
@@ -30,7 +29,6 @@ import {
   listBenchmarks,
   listModels,
   listPrices,
-  listSpeedSweeps,
   queryCompatibility,
   type CompatibilityFilters,
 } from "@/lib/registry"
@@ -100,7 +98,6 @@ export default async function Home({ searchParams }: PageProps) {
     retailer: value("retailer"),
   }, pagination) : { data: [], total: 0 }
   const priceTotal = counts.price ?? (topic === "prices" ? priceResults.total : listPrices({}, { limit: 1, offset: 0 }).total)
-  const sweepResults = topic === "speed-sweep" ? listSpeedSweeps({ q: query, recipe_id: value("recipe_id") }, pagination) : { data: [], total: 0 }
   const benchmarkResults = topic === "benchmark" ? listBenchmarks({ q: query, category: value("category") }, pagination) : { data: [], total: 0 }
   const matchCounts = !topic && query
     ? {
@@ -109,7 +106,6 @@ export default async function Home({ searchParams }: PageProps) {
         models: listModels({ q: query }, { limit: 1, offset: 0 }).total,
         prices: listPrices({ q: query }, { limit: 1, offset: 0 }).total,
         benchmark: listBenchmarks({ q: query }, { limit: 1, offset: 0 }).total,
-        "speed-sweep": undefined as number | undefined,
       }
     : null
 
@@ -132,7 +128,6 @@ export default async function Home({ searchParams }: PageProps) {
     models: modelResults.total,
     prices: priceResults.total,
     benchmark: benchmarkResults.total,
-    "speed-sweep": sweepResults.total,
   }
   const total = topic ? totals[topic] : 0
 
@@ -222,7 +217,6 @@ export default async function Home({ searchParams }: PageProps) {
           {topic === "models" && <ModelRows data={modelResults.data} state={viewState} />}
           {topic === "prices" && <PriceRows data={priceResults.data} state={viewState} />}
           {topic === "benchmark" && <BenchmarkRows data={benchmarkResults.data} state={viewState} />}
-          {topic === "speed-sweep" && <SweepRows data={sweepResults.data} state={viewState} />}
           {total === 0 && <div className="empty-state"><h2>No records found.</h2><p>Clear the search or remove a filter.</p></div>}
           {(offset > 0 || offset + limit < total) && (
             <nav aria-label={`${spec?.label} pages`} className="pagination">


### PR DESCRIPTION
Speed sweeps are a component of recipes, not a peer collection — the standalone browse topic and tab are removed. Measured speed remains on every recipe detail page (verified), launch-safe recipe rows keep their tok/s badges, and `/speed-sweep/<id>` permalinks + API stay live for provenance (breadcrumbs roll up to Recipes). Recipes topic description now says sweeps attach as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)