### PR TITLE
Render record data in the page; new wordmark

### DIFF
--- a/app/components/data-tree.tsx
+++ b/app/components/data-tree.tsx
@@ -52,16 +52,24 @@ function Scalar({ value }: { value: string | number | boolean | null }): ReactNo
   return <span>{value}</span>
 }
 
-function Branch({ value }: { value: unknown[] | Record<string, unknown> }) {
+const COLLAPSED_KEYS = new Set(["facts", "provenance", "sources", "source", "metadata"])
+const MAX_OPEN_DEPTH = 3
+
+function Branch({ value, open, depth }: { value: unknown[] | Record<string, unknown>; open: boolean; depth: number }) {
   return (
-    <details className="data-branch">
+    <details className="data-branch" open={open}>
       <summary>{branchSummary(value)}</summary>
-      <div className="data-branch-body"><DataTree nested value={value} /></div>
+      <div className="data-branch-body"><DataTree depth={open ? depth + 1 : MAX_OPEN_DEPTH} nested value={value} /></div>
     </details>
   )
 }
 
-export function DataTree({ nested = false, value }: { nested?: boolean; value: unknown }): ReactNode {
+function branchOpen(key: string | null, depth: number): boolean {
+  if (key !== null && COLLAPSED_KEYS.has(key)) return false
+  return depth < MAX_OPEN_DEPTH
+}
+
+export function DataTree({ nested = false, value, depth = 0 }: { nested?: boolean; value: unknown; depth?: number }): ReactNode {
   if (value === null || value === undefined) return <Scalar value={null} />
   if (typeof value !== "object") {
     return <Scalar value={value as string | number | boolean} />
@@ -74,8 +82,8 @@ export function DataTree({ nested = false, value }: { nested?: boolean; value: u
         {value.map((item, index) => (
           <li key={typeof item === "string" ? item : index}>
             {item !== null && typeof item === "object"
-              ? <Branch value={item as unknown[] | Record<string, unknown>} />
-              : <DataTree nested value={item} />}
+              ? <Branch depth={depth} open={branchOpen(null, depth)} value={item as unknown[] | Record<string, unknown>} />
+              : <DataTree depth={depth + 1} nested value={item} />}
           </li>
         ))}
       </ol>
@@ -89,8 +97,8 @@ export function DataTree({ nested = false, value }: { nested?: boolean; value: u
           <dt>{label(key)}</dt>
           <dd>
             {item !== null && typeof item === "object"
-              ? <Branch value={item as unknown[] | Record<string, unknown>} />
-              : <DataTree nested value={item} />}
+              ? <Branch depth={depth} open={branchOpen(key, depth)} value={item as unknown[] | Record<string, unknown>} />
+              : <DataTree depth={depth + 1} nested value={item} />}
           </dd>
         </div>
       ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,17 +78,13 @@ code, pre, kbd, .mono-label, .row-status, .topic-total, .pagination { font-famil
 }
 .wordmark:hover { color: white; }
 .wordmark-mark {
-  display: grid;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  color: var(--cream-ink);
-  background: var(--cream);
-  font-family: var(--font-mono);
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: -0.03em;
+  width: 26px;
+  height: 26px;
+  color: var(--cream);
+  flex-shrink: 0;
+  transition: color 0.15s ease;
 }
+.wordmark:hover .wordmark-mark { color: white; }
 .site-header nav { display: flex; gap: 18px; font-size: 0.75rem; }
 .site-header nav a { color: #c4c3be; text-decoration: none; }
 .site-header nav a:hover { color: white; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,12 @@ export default function RootLayout({ children }: Readonly<{ children: ReactNode 
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <header className="site-header">
           <Link className="wordmark" href="/">
-            <span className="wordmark-mark" aria-hidden="true">LAI</span>
+            <svg aria-hidden="true" className="wordmark-mark" fill="none" viewBox="0 0 30 30">
+              <rect height="21" rx="4.5" stroke="currentColor" strokeWidth="1.6" width="21" x="4.5" y="4.5" />
+              <path d="M9.5 4.5V2.2M15 4.5V2.2M20.5 4.5V2.2M9.5 27.8v-2.3M15 27.8v-2.3M20.5 27.8v-2.3M4.5 9.5H2.2M4.5 15H2.2M4.5 20.5H2.2M27.8 9.5h-2.3M27.8 15h-2.3M27.8 20.5h-2.3" stroke="currentColor" strokeLinecap="round" strokeWidth="1.4" />
+              <circle cx="15" cy="15" fill="currentColor" r="2.6" />
+              <path d="M15 10.2v2.2M15 17.6v2.2M10.2 15h2.2M17.6 15h2.2" stroke="currentColor" strokeLinecap="round" strokeWidth="1.4" />
+            </svg>
             <span>Local AI Registry</span>
           </Link>
           <nav aria-label="Primary navigation">


### PR DESCRIPTION
Detail pages now show the actual data: DataTree renders expanded to three levels (commercial prices, compute stats, serving details all visible inline) with provenance/sources/facts/metadata kept behind toggles. The `LAI` text-box logo is replaced with an inline chip-with-pins SVG mark that inherits the wordmark color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)