### PR TITLE
Vendor-published compute throughput for the hardware collection

### DIFF
--- a/registry/hardware/apple-m1-16gb.json
+++ b/registry/hardware/apple-m1-16gb.json
@@ -182,42 +182,21 @@
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Apple",
                 "url": "https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2020/11/introducing-the-next-generation-of-mac/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/mac/compare/?modelList=Mac-mini-M1%2CMac-mini-M2"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2021/04/imac-features-all-new-design-in-vibrant-colors-m1-chip-and-45k-retina-display/"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "Apple does not publish a directly comparable compute-throughput figure for this exact chip/memory record; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 2.6
         }
       },
       "fp8": {

--- a/registry/hardware/apple-m1-8gb.json
+++ b/registry/hardware/apple-m1-8gb.json
@@ -182,42 +182,21 @@
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Apple",
                 "url": "https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2020/11/introducing-the-next-generation-of-mac/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/mac/compare/?modelList=Mac-mini-M1%2CMac-mini-M2"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2021/04/imac-features-all-new-design-in-vibrant-colors-m1-chip-and-45k-retina-display/"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "Apple does not publish a directly comparable compute-throughput figure for this exact chip/memory record; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 2.6
         }
       },
       "fp8": {

--- a/registry/hardware/apple-m2-ultra-128gb.json
+++ b/registry/hardware/apple-m2-ultra-128gb.json
@@ -130,30 +130,21 @@
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-introduces-m2-ultra/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-unveils-new-mac-studio-and-brings-apple-silicon-to-mac-pro/"
+                "url": "https://www.apple.com/shop/product/g1jz5ll/a/Refurbished-Mac-Pro-Apple-M2-Ultra-with-24-core-CPU-and-60-core-GPU-USB-C"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "Apple does not publish a directly comparable compute-throughput figure for this exact chip/memory record; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 27.2
         }
       },
       "fp8": {

--- a/registry/hardware/apple-m2-ultra-192gb.json
+++ b/registry/hardware/apple-m2-ultra-192gb.json
@@ -130,30 +130,21 @@
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-introduces-m2-ultra/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-unveils-new-mac-studio-and-brings-apple-silicon-to-mac-pro/"
+                "url": "https://www.apple.com/shop/product/g1jz5ll/a/Refurbished-Mac-Pro-Apple-M2-Ultra-with-24-core-CPU-and-60-core-GPU-USB-C"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "Apple does not publish a directly comparable compute-throughput figure for this exact chip/memory record; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 27.2
         }
       },
       "fp8": {

--- a/registry/hardware/apple-m2-ultra-64gb.json
+++ b/registry/hardware/apple-m2-ultra-64gb.json
@@ -130,30 +130,21 @@
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-introduces-m2-ultra/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "Apple",
-                "url": "https://www.apple.com/newsroom/2023/06/apple-unveils-new-mac-studio-and-brings-apple-silicon-to-mac-pro/"
+                "url": "https://www.apple.com/shop/product/g1jz5ll/a/Refurbished-Mac-Pro-Apple-M2-Ultra-with-24-core-CPU-and-60-core-GPU-USB-C"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "Apple does not publish a directly comparable compute-throughput figure for this exact chip/memory record; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 27.2
         }
       },
       "fp8": {

--- a/registry/hardware/intel-arc-pro-b60-24gb.json
+++ b/registry/hardware/intel-arc-pro-b60-24gb.json
@@ -156,24 +156,27 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Intel",
                 "url": "https://www.intel.com/content/www/us/en/products/sku/243916/intel-arc-pro-b60-graphics/specifications.html"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "Intel",
+                "url": "https://www.intel.com/content/dam/www/central-libraries/us/en/documents/2026-03/intel-arc-pro-b-series-graphics-quick-reference-guide-v1-0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 197
         }
       },
       "tf32": {

--- a/registry/hardware/intel-arc-pro-b70-32gb.json
+++ b/registry/hardware/intel-arc-pro-b70-32gb.json
@@ -215,30 +215,27 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Intel",
-                "url": "https://www.thailand.intel.com/content/www/th/th/products/sku/245797/intel-arc-pro-b70-graphics/specifications.html"
+                "url": "https://www.intel.com/content/www/us/en/products/sku/245797/intel-arc-pro-b70-graphics/specifications.html"
               },
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "Intel",
-                "url": "https://newsroom.intel.com/client-computing/intel-core-ultra-series-3-with-vpro-powers-next-gen-pcs-built-on-intel-18a"
+                "url": "https://www.intel.com/content/dam/www/central-libraries/us/en/documents/2026-03/datasheet-b70-gpu.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 367
         }
       },
       "tf32": {

--- a/registry/hardware/mi300x-192gb.json
+++ b/registry/hardware/mi300x-192gb.json
@@ -192,45 +192,95 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
                 "url": "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 2614.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 5229.8
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
                 "url": "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 653.7
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1307.4
         }
       }
     },

--- a/registry/hardware/radeon-ai-pro-r9700-32gb.json
+++ b/registry/hardware/radeon-ai-pro-r9700-32gb.json
@@ -230,57 +230,71 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
                 "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 766
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1531
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
                 "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 383
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 766
         }
       },
       "tf32": {

--- a/registry/hardware/rtx-2000-ada-16gb.json
+++ b/registry/hardware/rtx-2000-ada-16gb.json
@@ -116,24 +116,21 @@
         }
       },
       "fp8": {
-        "unknown": {
+        "structured_2_4": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/products/workstations/rtx-2000/"
+                "url": "https://www.nvidia.com/en-au/products/workstations/rtx-2000/"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 191.9
         }
       },
       "int4": {

--- a/registry/hardware/rtx-3070-8gb.json
+++ b/registry/hardware/rtx-3070-8gb.json
@@ -71,102 +71,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 40.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 81.3
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 81.3
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 162.6
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 20.3
         }
       },
       "fp8": {
@@ -203,102 +190,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 325.2
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 650.4
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 162.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 325.2
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 20.3
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 40.6
         }
       }
     },

--- a/registry/hardware/rtx-3080-10gb.json
+++ b/registry/hardware/rtx-3080-10gb.json
@@ -65,84 +65,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 59.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 119
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 119
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 238
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 29.8
         }
       },
       "fp8": {
@@ -173,84 +178,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 476
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 952
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 238
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 476
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 29.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 59.5
         }
       }
     },

--- a/registry/hardware/rtx-3080-12gb.json
+++ b/registry/hardware/rtx-3080-12gb.json
@@ -39,66 +39,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 59.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 119
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 119
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 238
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 29.8
         }
       },
       "fp8": {
@@ -123,66 +146,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 476
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 952
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 238
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 476
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 29.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 59.5
         }
       }
     },

--- a/registry/hardware/rtx-3080-ti-12gb.json
+++ b/registry/hardware/rtx-3080-ti-12gb.json
@@ -65,84 +65,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 68.2
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 136.4
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 136.4
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 272.8
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 34.1
         }
       },
       "fp8": {
@@ -173,84 +178,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 545.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1091.2
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 272.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 545.6
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/_gallery/download_pdf/60b5c5d3ed6ae549cd412209/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 34.1
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 68.2
         }
       }
     },

--- a/registry/hardware/rtx-3090-24gb.json
+++ b/registry/hardware/rtx-3090-24gb.json
@@ -65,84 +65,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 71
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 142
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 142
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 284
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 35.6
         }
       },
       "fp8": {
@@ -173,84 +178,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 568
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1136
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 284
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 568
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-delivers-greatest-ever-generational-leap-in-performance-with-geforce-rtx-30-series-gpus"
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 35.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.1.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 71
         }
       }
     },

--- a/registry/hardware/rtx-3090-ti-24gb.json
+++ b/registry/hardware/rtx-3090-ti-24gb.json
@@ -45,84 +45,89 @@
     "rt_cores": "2nd generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 80
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 160
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 160
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 320
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 40
         }
       },
       "fp8": {
@@ -153,84 +158,105 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 640
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1280
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 320
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 640
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 40
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 80
         }
       }
     },

--- a/registry/hardware/rtx-5070-12gb.json
+++ b/registry/hardware/rtx-5070-12gb.json
@@ -65,111 +65,157 @@
     "rt_core_tflops": 94,
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 61.7
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 123.5
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 123.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 246.9
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 30.9
+        }
+      },
+      "fp4": {
+        "dense": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 493.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 987.8
         }
       },
       "fp8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 246.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 493.9
         }
       },
       "int4": {
@@ -200,57 +246,71 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 246.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 493.9
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 30.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 61.7
         }
       }
     },

--- a/registry/hardware/rtx-5070-ti-16gb.json
+++ b/registry/hardware/rtx-5070-ti-16gb.json
@@ -65,111 +65,157 @@
     "rt_core_tflops": 133,
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 87.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 175.8
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 175.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 351.5
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 43.9
+        }
+      },
+      "fp4": {
+        "dense": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 703
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 1406
         }
       },
       "fp8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 351.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 703
         }
       },
       "int4": {
@@ -200,57 +246,71 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 351.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 703
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 43.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 87.9
         }
       }
     },

--- a/registry/hardware/rtx-5080-16gb.json
+++ b/registry/hardware/rtx-5080-16gb.json
@@ -65,111 +65,157 @@
     "rt_core_tflops": 171,
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 112.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 225.1
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 225.1
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 450.2
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 56.3
+        }
+      },
+      "fp4": {
+        "dense": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 900.4
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 1801
         }
       },
       "fp8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 450.2
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 900.4
         }
       },
       "int4": {
@@ -200,57 +246,71 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 450.2
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 900.4
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 56.3
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 112.6
         }
       }
     },

--- a/registry/hardware/rtx-5090-32gb.json
+++ b/registry/hardware/rtx-5090-32gb.json
@@ -65,111 +65,157 @@
     "rt_core_tflops": 318,
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 209.5
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 419
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 419
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 838
         }
       },
       "fp32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 104.8
+        }
+      },
+      "fp4": {
+        "dense": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1676
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 3352
         }
       },
       "fp8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 838
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1676
         }
       },
       "int4": {
@@ -200,57 +246,71 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 838
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1676
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/en-us/geforce/graphics-cards/compare/?section=compare-specs"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "NVIDIA",
-                "url": "https://nvidianews.nvidia.com/news/nvidia-blackwell-geforce-rtx-50-series-opens-new-world-of-ai-computer-graphics"
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 104.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 209.5
         }
       }
     },

--- a/registry/hardware/rtx-pro-4000-blackwell-24gb.json
+++ b/registry/hardware/rtx-pro-4000-blackwell-24gb.json
@@ -116,6 +116,24 @@
           "unit": "tflops"
         }
       },
+      "fp4": {
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/products/workstations/professional-desktop-gpus/rtx-pro-4000/workstation-datasheet-rtx-pro-4000-nvidia-us-web.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 1178
+        }
+      },
       "fp8": {
         "unknown": {
           "provenance": {

--- a/registry/hardware/rtx-pro-4500-blackwell-32gb.json
+++ b/registry/hardware/rtx-pro-4500-blackwell-32gb.json
@@ -148,6 +148,24 @@
           "unit": "tflops"
         }
       },
+      "fp4": {
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-4500-blackwell/workstation-datasheet-blackwell-rtx-pro-4500-we-nvidia-us-5108623-web.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 1617
+        }
+      },
       "fp8": {
         "dense": {
           "provenance": {

--- a/registry/hardware/rtx-pro-6000-blackwell-96gb.json
+++ b/registry/hardware/rtx-pro-6000-blackwell-96gb.json
@@ -40,45 +40,71 @@
     "rt_cores": "4th generation",
     "stats": {
       "bf16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-6000-blackwell-workstation-edition/workstation-blackwell-rtx-pro-6000-workstation-edition-nvidia-us-3519208-web.pdf"
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable bf16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 251.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 503.8
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-6000-blackwell-workstation-edition/workstation-blackwell-rtx-pro-6000-workstation-edition-nvidia-us-3519208-web.pdf"
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 503.8
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1007.6
         }
       },
       "fp32": {
@@ -118,25 +144,72 @@
           "unit": "tflops"
         }
       },
-      "fp8": {
-        "unknown": {
+      "fp4": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-6000-blackwell-workstation-edition/workstation-blackwell-rtx-pro-6000-workstation-edition-nvidia-us-3519208-web.pdf"
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 2015.2
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 4030.4
+        }
+      },
+      "fp8": {
+        "dense": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 1007.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
+          },
+          "state": "known",
+          "unit": "tflops",
+          "value": 2015.2
         }
       },
       "int4": {
@@ -161,45 +234,71 @@
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-6000-blackwell-workstation-edition/workstation-blackwell-rtx-pro-6000-workstation-edition-nvidia-us-3519208-web.pdf"
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 1007.6
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 2015.2
         }
       },
       "tf32": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "NVIDIA",
-                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/data-center/rtx-pro-6000-blackwell-workstation-edition/workstation-blackwell-rtx-pro-6000-workstation-edition-nvidia-us-3519208-web.pdf"
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable tf32 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 251.9
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "NVIDIA",
+                "url": "https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 503.8
         }
       }
     },

--- a/registry/hardware/rx-7700-xt-12gb.json
+++ b/registry/hardware/rx-7700-xt-12gb.json
@@ -89,30 +89,21 @@
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://www.amd.com/en/newsroom/press-releases/2023-8-25-new-amd-radeon-rx-7800-xt-and-amd-radeon-rx-7700-xt-gr.html"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7700-xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 70.3
         }
       },
       "fp32": {
@@ -192,57 +183,39 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://www.amd.com/en/newsroom/press-releases/2023-8-25-new-amd-radeon-rx-7800-xt-and-amd-radeon-rx-7700-xt-gr.html"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7700-xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 141
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://www.amd.com/en/newsroom/press-releases/2023-8-25-new-amd-radeon-rx-7800-xt-and-amd-radeon-rx-7700-xt-gr.html"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7700-xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 70.3
         }
       },
       "tf32": {

--- a/registry/hardware/rx-7900-xt-20gb.json
+++ b/registry/hardware/rx-7900-xt-20gb.json
@@ -214,57 +214,39 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1099/amd-unveils-worlds-most-advanced-gaming-graphics-cards-built-on-groundbreaking-amd-rdna-3-architecture-with-chiplet-design"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 206
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1099/amd-unveils-worlds-most-advanced-gaming-graphics-cards-built-on-groundbreaking-amd-rdna-3-architecture-with-chiplet-design"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 103
         }
       },
       "tf32": {

--- a/registry/hardware/rx-7900-xtx-24gb.json
+++ b/registry/hardware/rx-7900-xtx-24gb.json
@@ -216,57 +216,39 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1099/amd-unveils-worlds-most-advanced-gaming-graphics-cards-built-on-groundbreaking-amd-rdna-3-architecture-with-chiplet-design"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xtx.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 246
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1099/amd-unveils-worlds-most-advanced-gaming-graphics-cards-built-on-groundbreaking-amd-rdna-3-architecture-with-chiplet-design"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xtx.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 123
         }
       },
       "tf32": {

--- a/registry/hardware/rx-9070-xt-16gb.json
+++ b/registry/hardware/rx-9070-xt-16gb.json
@@ -233,57 +233,71 @@
         }
       },
       "int4": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1238/amd-unveils-next-generation-amd-rdna-4-architecture-with-the-launch-of-amd-radeon-rx-9000-series-graphics-cards"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9070xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int4 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 779
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9070xt.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 1557
         }
       },
       "int8": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
-                "url": "https://www.amd.com/en/products/specifications/graphics.html"
-              },
-              {
-                "captured_at": "2026-08-27T04:55:00Z",
-                "kind": "vendor",
-                "publisher": "AMD",
-                "url": "https://ir.amd.com/news-events/press-releases/detail/1238/amd-unveils-next-generation-amd-rdna-4-architecture-with-the-launch-of-amd-radeon-rx-9000-series-graphics-cards"
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9070xt.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable int8 throughput was published for this exact accelerator; no FLOPS inferred."
+          "state": "known",
+          "unit": "tflops",
+          "value": 389
+        },
+        "structured_2_4": {
+          "provenance": {
+            "captured_at": "2026-08-31T13:46:11Z",
+            "sources": [
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9070xt.html"
+              }
+            ]
           },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 779
         }
       },
       "tf32": {

--- a/registry/hardware/ryzen-ai-max-plus-395-128gb.json
+++ b/registry/hardware/ryzen-ai-max-plus-395-128gb.json
@@ -58,24 +58,27 @@
         }
       },
       "fp16": {
-        "unknown": {
+        "dense": {
           "provenance": {
-            "captured_at": "2026-08-27T04:55:00Z",
+            "captured_at": "2026-08-31T13:46:11Z",
             "sources": [
               {
-                "captured_at": "2026-08-27T04:55:00Z",
+                "captured_at": "2026-08-31T13:46:11Z",
+                "kind": "vendor",
+                "publisher": "AMD",
+                "url": "https://www.amd.com/en/products/processors/desktops/ryzen/ryzen-ai-halo.html"
+              },
+              {
+                "captured_at": "2026-08-31T13:46:11Z",
                 "kind": "vendor",
                 "publisher": "AMD",
                 "url": "https://www.amd.com/en/products/processors/laptop/ryzen/ai-300-series/amd-ryzen-ai-max-plus-395.html"
               }
             ]
           },
-          "reason": {
-            "code": "not-published",
-            "detail": "No directly comparable fp16 throughput was published for this exact accelerator; no FLOPS inferred."
-          },
-          "state": "unknown",
-          "unit": "tflops"
+          "state": "known",
+          "unit": "tflops",
+          "value": 60
         }
       },
       "fp32": {


### PR DESCRIPTION
Three parallel codex-cli (gpt-5.6-terra) research runs over 61 chip groups, vendor sources only (NVIDIA/AMD/Intel/Apple datasheets and spec pages), values recorded exactly as published with sparsity labeled — never derived. Gate: vendor-domain enforcement, range + dense≤sparse sanity, >10% divergence vs already-trusted values rejects the chip (zero tripped), all 30 source URLs HTTP-verified.

**160 new stat entries across 28 hardware records** — e.g. RTX 5090 now carries the full Blackwell matrix (fp4 1,676 dense / 3,352 sparse TFLOPS). Already-audited blocks untouched; Apple stays honestly unknown (2 published figures across 20 chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)