### PR TITLE
Add UK DGX Spark used sale observation

### DIFF
--- a/registry/price/dgx-spark/gb.json
+++ b/registry/price/dgx-spark/gb.json
@@ -17,9 +17,20 @@
       "retailer": "cclonline",
       "title": "Nvidia DGX Spark GB10 128 GB LPDDR5x-SDRAM 4 TB SSD DGX OS Workstation Gold",
       "url": "https://www.cclonline.com/dgxspark-founedit-uk-nvidia-dgx-spark-gb10-128-gb-lpddr5x-sdram-4-tb-ssd-dgx-os-workstation-gold-510831/"
+    },
+    {
+      "amount": 4073.52,
+      "condition": "used",
+      "currency": "GBP",
+      "in_stock": false,
+      "observed_at": "2026-08-31T13:29:30Z",
+      "quantity": 0,
+      "retailer": "ebay",
+      "title": "NVIDIA DGX Spark - 128GB RAM - 4TB SSD - Blackwell - Mint - UK",
+      "url": "https://www.ebay.co.uk/itm/267740485677"
     }
   ],
-  "observed_at": "2026-08-31T11:49:06Z",
+  "observed_at": "2026-08-31T13:29:30Z",
   "product": {
     "category": "gpu",
     "id": "dgx-spark",
@@ -27,7 +38,7 @@
   },
   "provenance": {
     "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:12:00.000Z",
+    "snapshot_generated_at": "2026-08-31T13:29:30Z",
     "source_error_count": 200
   },
   "region": {
@@ -38,14 +49,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 1,
+    "listing_count": 2,
     "lowest_new": 4899.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "codex-cli (gpt-5.6-terra) live web search; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; completed eBay sale retained as unavailable used-market evidence",
     "rejected_observations": 0,
     "state": "candidate"
   }


### PR DESCRIPTION
## Summary

- add a completed UK eBay sale as used-market evidence for NVIDIA DGX Spark
- preserve the sold listing as unavailable (`in_stock: false`, `quantity: 0`)
- update UK listing and retailer counts without treating the sold unit as current stock

## Source

- https://www.ebay.co.uk/itm/267740485677
- Sold 6 August 2026 for £4,073.52 including buyer protection; used condition; six bids; located in Leeds

## Validation

- `python3 scripts/validate_registry.py`
- targeted JSON assertions for amount, condition, stock state, quantity, and summary counts
- `git diff --check upstream/main...HEAD`
