### PR TITLE
Hardware clarity: clean stats, live market panel, /compare

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { CollectionNav } from "@/app/components/collection-nav"
+import { hardwareComparison, type HardwareComparisonRow } from "@/lib/registry"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = { title: "Compare hardware · Local AI Registry" }
+
+type SortKey = "name" | "vram" | "bandwidth" | "fp16" | "fp8" | "int8" | "price" | "recipes"
+
+const COLUMNS: Array<{ key: SortKey; label: string }> = [
+  { key: "name", label: "Hardware" },
+  { key: "vram", label: "VRAM" },
+  { key: "bandwidth", label: "Bandwidth" },
+  { key: "fp16", label: "FP16 TFLOPS" },
+  { key: "fp8", label: "FP8 TFLOPS" },
+  { key: "int8", label: "INT8 TOPS" },
+  { key: "price", label: "Lowest new (US)" },
+  { key: "recipes", label: "Recipes" },
+]
+
+function metric(row: HardwareComparisonRow, key: SortKey): number | string | null {
+  if (key === "name") return row.name
+  if (key === "vram") return row.vram_gb
+  if (key === "bandwidth") return row.bandwidth_gb_per_s
+  if (key === "fp16") return row.fp16_tflops
+  if (key === "fp8") return row.fp8_tflops
+  if (key === "int8") return row.int8_tflops
+  if (key === "price") return row.lowest_new_usd
+  return row.recipe_count
+}
+
+function cell(value: number | null, sparse = false): string {
+  if (value === null) return "—"
+  return `${value.toLocaleString("en-US")}${sparse ? " *" : ""}`
+}
+
+export default async function ComparePage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
+  const params = await searchParams
+  const sortParam = Array.isArray(params.sort) ? params.sort[0] : params.sort
+  const sort: SortKey = COLUMNS.some((column) => column.key === sortParam) ? (sortParam as SortKey) : "fp16"
+  const vendorParam = Array.isArray(params.vendor) ? params.vendor[0] : params.vendor ?? ""
+
+  let rows = hardwareComparison()
+  const vendors = [...new Set(rows.map((row) => row.vendor))].sort()
+  if (vendorParam) rows = rows.filter((row) => row.vendor === vendorParam)
+  rows.sort((left, right) => {
+    if (sort === "name") return left.name.localeCompare(right.name, undefined, { numeric: true })
+    const a = metric(left, sort) as number | null
+    const b = metric(right, sort) as number | null
+    return (b ?? -1) - (a ?? -1) || left.name.localeCompare(right.name)
+  })
+
+  const href = (key: SortKey) => `/compare?sort=${key}${vendorParam ? `&vendor=${vendorParam}` : ""}`
+
+  return (
+    <main className="detail-page">
+      <CollectionNav current="hardware" />
+      <header className="topic-heading">
+        <div>
+          <span className="mono-label">COLLECTION / COMPARE</span>
+          <h1>Compare hardware</h1>
+          <p className="topic-description">
+            Every accelerator side by side: memory, vendor-published throughput, the lowest live US listing, and how
+            many launch recipes the registry holds. Click a column to rank by it; * marks structured-sparsity figures
+            where the vendor publishes no dense number.
+          </p>
+        </div>
+        <span className="topic-total">{rows.length.toLocaleString("en-US")} devices</span>
+      </header>
+      <nav aria-label="Vendor filter" className="breadcrumbs">
+        <Link href={`/compare?sort=${sort}`}>{vendorParam ? "all vendors" : "· all vendors"}</Link>
+        {vendors.map((vendor) => (
+          <Link href={`/compare?sort=${sort}&vendor=${vendor}`} key={vendor}>{vendorParam === vendor ? `· ${vendor}` : vendor}</Link>
+        ))}
+      </nav>
+      <section className="record-evidence">
+        <table className="flag-table">
+          <thead>
+            <tr>
+              {COLUMNS.map((column) => (
+                <th key={column.key} scope="col">
+                  <Link href={href(column.key)}>{sort === column.key ? `▾ ${column.label}` : column.label}</Link>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id}>
+                <td><Link href={`/hardware/${row.id}`}>{row.name}</Link></td>
+                <td>{row.vram_gb.toLocaleString("en-US")} GB</td>
+                <td>{row.bandwidth_gb_per_s === null ? "—" : `${row.bandwidth_gb_per_s.toLocaleString("en-US")} GB/s`}</td>
+                <td>{cell(row.fp16_tflops, row.fp16_sparse)}</td>
+                <td>{cell(row.fp8_tflops, row.fp8_sparse)}</td>
+                <td>{cell(row.int8_tflops, row.int8_sparse)}</td>
+                <td>{row.lowest_new_usd === null ? "—" : `$${row.lowest_new_usd.toLocaleString("en-US", { maximumFractionDigits: 0 })}`}</td>
+                <td>{row.recipe_count.toLocaleString("en-US")}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  )
+}

--- a/app/components/hardware-market.tsx
+++ b/app/components/hardware-market.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link"
+
+import { getHardwareMarket } from "@/lib/registry"
+
+function money(amount: number | null, currency: string): string {
+  if (amount === null) return "—"
+  return `${currency} ${amount.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+}
+
+function day(value: string): string {
+  return value.slice(0, 10)
+}
+
+export function HardwareMarket({ hardwareId }: { hardwareId: string }) {
+  const market = getHardwareMarket(hardwareId)
+  if (market.length === 0) return null
+  return (
+    <section aria-label="Current market prices" className="record-evidence">
+      <p className="eyebrow">Current market</p>
+      <p className="trust-note">
+        Lowest live retailer listings per region, in native currency, from the market price collection. Each row links
+        to the underlying observations with retailer and URL.
+      </p>
+      <table className="flag-table">
+        <thead>
+          <tr>
+            <th>Region</th>
+            <th>Lowest new</th>
+            <th>Refurbished</th>
+            <th>Used</th>
+            <th>Listings</th>
+            <th>Observed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {market.map((row) => (
+            <tr key={row.record_id}>
+              <td><Link href={`/prices/${row.record_id}`}>{row.region}</Link></td>
+              <td>{money(row.lowest_new, row.currency)}</td>
+              <td>{money(row.lowest_refurbished, row.currency)}</td>
+              <td>{money(row.lowest_used, row.currency)}</td>
+              <td>{row.listing_count.toLocaleString("en-US")} · {row.retailer_count.toLocaleString("en-US")} retailers</td>
+              <td>{day(row.observed_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/app/components/record-body.tsx
+++ b/app/components/record-body.tsx
@@ -1,6 +1,7 @@
 import { ConfigurationCard, configurationFromRecipe } from "@/app/components/configuration-card"
 import { CopyActions } from "@/app/components/copy-actions"
 import { RecordSheet } from "@/app/components/record-sheet"
+import { HardwareMarket } from "@/app/components/hardware-market"
 import { HuggingFaceCard } from "@/app/components/huggingface-card"
 import { ModelScores } from "@/app/components/model-scores"
 import { RecordEvidence } from "@/app/components/record-evidence"
@@ -49,6 +50,7 @@ export function RecordBody({
         </>
       )}
       <RecordEvidence collection={collection} record={record} />
+      {collection === "hardware" && typeof record.id === "string" && <HardwareMarket hardwareId={record.id} />}
       {collection === "models" && typeof record.id === "string" && <ModelScores modelId={record.id} />}
       <RelatedRecords groups={groups} />
       {variant === "page" ? (

--- a/app/components/record-sheet.tsx
+++ b/app/components/record-sheet.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react"
 
 type Row = { label: string; value: unknown }
 
-const QUIET_KEYS = new Set(["provenance", "facts", "metadata", "source", "sources"])
+const QUIET_KEYS = new Set(["provenance", "facts", "metadata", "source", "sources", "state", "reason", "unit", "prices"])
 
 function label(value: string): string {
   return value.replaceAll("_", " ")
@@ -60,7 +60,12 @@ function explode(name: string, value: Record<string, unknown>): Record<string, u
   const entries = Object.entries(value)
   const allObjects = entries.length > 0 && entries.every(([, item]) => item !== null && typeof item === "object" && !Array.isArray(item))
   if (allObjects) {
-    return entries.map(([variant, item]) => ({ "": name, variant, ...(item as Record<string, unknown>) }))
+    return entries
+      .filter(([, item]) => {
+        const state = (item as Record<string, unknown>).state
+        return state === undefined || state === "known"
+      })
+      .map(([variant, item]) => ({ "": name, variant, ...(item as Record<string, unknown>) }))
   }
   return [{ "": name, ...value }]
 }
@@ -84,10 +89,10 @@ function flatten(value: Record<string, unknown>, prefix = ""): { rows: Row[]; ta
       continue
     }
     if (isScalar(item)) {
-      rows.push({ label: path, value: item })
+      if (item !== null && item !== "") rows.push({ label: path, value: item })
     } else if (Array.isArray(item)) {
       if (item.length === 0) {
-        rows.push({ label: path, value: null })
+        continue
       } else if (item.every(isScalar)) {
         rows.push({ label: path, value: item.map((entry) => String(entry)).join(", ") })
       } else {
@@ -144,7 +149,7 @@ function Cell({ value }: { value: unknown }): ReactNode {
 
 function SheetTable({ caption, rows }: { caption: string; rows: Record<string, unknown>[] }) {
   const columns = columnsOf(rows)
-  if (columns.length === 0) return null
+  if (columns.length === 0 || rows.length === 0) return null
   return (
     <div className="sheet-table">
       <p className="sheet-caption">{caption}</p>
@@ -239,10 +244,10 @@ export function RecordSheet({ record }: { record: Record<string, unknown> }) {
       continue
     }
     if (isScalar(value)) {
-      scalarRows.push({ label: label(key), value })
+      if (value !== null && value !== "") scalarRows.push({ label: label(key), value })
     } else if (Array.isArray(value)) {
       if (value.length === 0) {
-        scalarRows.push({ label: label(key), value: null })
+        continue
       } else if (value.every(isScalar)) {
         scalarRows.push({ label: label(key), value: value.map((entry) => String(entry)).join(", ") })
       } else {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,6 +28,7 @@ export default function RootLayout({ children }: Readonly<{ children: ReactNode 
             <span>Local AI Registry</span>
           </Link>
           <nav aria-label="Primary navigation">
+            <Link href="/compare">Compare</Link>
             <Link href="/api/v1">API</Link>
             <a href="https://github.com/0xSero/local-ai-registry#read-only-api">Docs</a>
           </nav>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -223,6 +223,106 @@ export function getModelBenchmarkScores(modelId: string): ModelBenchmarkScore[] 
   return cachedScores[modelId] ?? []
 }
 
+export type RegionMarket = {
+  record_id: string
+  region: string
+  currency: string
+  lowest_new: number | null
+  lowest_refurbished: number | null
+  lowest_used: number | null
+  listing_count: number
+  retailer_count: number
+  observed_at: string
+}
+
+let cachedPricesByHardware: Record<string, string[]> | undefined
+
+function pricesByHardware(): Record<string, string[]> {
+  if (!cachedPricesByHardware) {
+    cachedPricesByHardware = readJson<{ prices_by_hardware: Record<string, string[]> }>(
+      "index",
+      "prices-by-hardware.json",
+    ).prices_by_hardware
+  }
+  return cachedPricesByHardware
+}
+
+export function getHardwareMarket(hardwareId: string): RegionMarket[] {
+  const ids = pricesByHardware()[hardwareId] ?? []
+  const rows: RegionMarket[] = []
+  for (const id of ids) {
+    const record = dataset().prices.get(id)
+    if (!record) continue
+    rows.push({
+      record_id: id,
+      region: record.region.code,
+      currency: record.region.currency,
+      lowest_new: record.summary.lowest_new,
+      lowest_refurbished: record.summary.lowest_refurbished,
+      lowest_used: record.summary.lowest_used,
+      listing_count: record.summary.listing_count,
+      retailer_count: record.summary.retailer_count,
+      observed_at: record.observed_at,
+    })
+  }
+  return rows.sort((left, right) => left.region.localeCompare(right.region))
+}
+
+export type HardwareComparisonRow = {
+  id: string
+  name: string
+  vendor: string
+  vram_gb: number
+  bandwidth_gb_per_s: number | null
+  fp16_tflops: number | null
+  fp8_tflops: number | null
+  int8_tflops: number | null
+  fp16_sparse: boolean
+  fp8_sparse: boolean
+  int8_sparse: boolean
+  lowest_new_usd: number | null
+  price_observed_at: string | null
+  recipe_count: number
+}
+
+function bestThroughput(record: Hardware, dtype: string): { value: number | null; sparse: boolean } {
+  const stats = (record.compute?.stats ?? {}) as Record<string, Record<string, { state?: string; value?: number | null }>>
+  const entry = stats[dtype]
+  if (!entry) return { value: null, sparse: false }
+  const dense = entry.dense
+  if (dense?.state === "known" && typeof dense.value === "number") return { value: dense.value, sparse: false }
+  const sparse = entry.structured_2_4
+  if (sparse?.state === "known" && typeof sparse.value === "number") return { value: sparse.value, sparse: true }
+  return { value: null, sparse: false }
+}
+
+export function hardwareComparison(): HardwareComparisonRow[] {
+  const data = dataset()
+  return [...data.hardware.values()].map((record) => {
+    const fp16 = bestThroughput(record, "fp16")
+    const fp8 = bestThroughput(record, "fp8")
+    const int8 = bestThroughput(record, "int8")
+    const market = getHardwareMarket(record.id)
+    const us = market.find((row) => row.region === "US" && row.lowest_new !== null)
+    return {
+      id: record.id,
+      name: record.name,
+      vendor: record.vendor,
+      vram_gb: record.memory.vram_gb,
+      bandwidth_gb_per_s: record.memory.bandwidth_gb_per_s as number | null,
+      fp16_tflops: fp16.value,
+      fp8_tflops: fp8.value,
+      int8_tflops: int8.value,
+      fp16_sparse: fp16.sparse,
+      fp8_sparse: fp8.sparse,
+      int8_sparse: int8.sparse,
+      lowest_new_usd: us?.lowest_new ?? null,
+      price_observed_at: us?.observed_at ?? null,
+      recipe_count: recipeCountForHardware(record.id),
+    }
+  })
+}
+
 export function getBenchmark(id: string): Benchmark | undefined {
   return dataset().benchmarks.get(id)
 }


### PR DESCRIPTION
Addresses three issues: (1) `state`/`reason`/`unit` plumbing and Unknown rows are gone from visible tables — throughput reads as precision · variant · value only; (2) the stale Aug-27 commercial snapshots stop masquerading as current prices — hardware pages now carry a **Current market** panel with lowest live listings per region (dated, linked to observations); (3) new **/compare** page ranks all devices by VRAM, bandwidth, FP16/FP8/INT8 throughput (sparse-only flagged `*`), lowest live US price, or recipe count, with vendor filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)