### PR TITLE
Portable mounts for glm52-exl3; CI runs the Omarchy plugin gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Referential integrity and trust boundary
         run: python3 scripts/validate_registry.py
 
+      - name: Omarchy plugin gate accepts every validated Docker recipe
+        run: python3 scripts/check_plugin_gate.py
+
       - name: index shards match the records they summarize
         run: |
           python3 scripts/curate_registry.py --index-only

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 # All Python scripts are stdlib-only (Python >= 3.10). Node is needed for
 # tests, typecheck, and the site. `make check` is what CI runs.
 
-.PHONY: check format index types validate test typecheck build
+.PHONY: check format index types validate plugin-gate test typecheck build
 
 ## The full verification suite — identical to CI.
-check: format-check validate test typecheck types-check index-check
+check: format-check validate plugin-gate test typecheck types-check index-check
 
 ## Rewrite every registry JSON file into canonical form.
 format:
@@ -36,6 +36,10 @@ types-check:
 ## Referential integrity, trust boundary, index staleness.
 validate:
 	python3 scripts/validate_registry.py
+
+## Omarchy local-ai plugin gate over every validated Docker recipe.
+plugin-gate:
+	python3 scripts/check_plugin_gate.py
 
 ## Node test suite (includes ajv validation of every record).
 test:

--- a/registry/recipe/glm52-exl3-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/glm52-exl3-rtxpro6000-vllm-tp4.json
@@ -113,12 +113,12 @@
     "mounts": [
       {
         "read_only": true,
-        "source": "/mnt/llm_models/GLM-5.2-EXL3-TR3-3.0bpw",
+        "source": "${MODEL_ROOT}/GLM-5.2-EXL3-TR3-3.0bpw",
         "target": "/model"
       },
       {
         "read_only": false,
-        "source": "/mnt/llm_models/cache_glm52_exl3_text",
+        "source": "${CACHE_ROOT}/cache_glm52_exl3_text",
         "target": "/cache"
       }
     ],

--- a/scripts/check_plugin_gate.py
+++ b/scripts/check_plugin_gate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Run the Omarchy local-ai plugin's recipe gate against every validated Docker recipe.
+
+The plugin (basecamp/omarchy PR #8836) refuses to launch a recipe unless it
+passes a safety gate: the record chain must resolve, the image must be
+digest-pinned, the model revision must be pinned, and every mount source must
+be a portable path — a ${MODEL_ROOT}/${CACHE_ROOT} placeholder, a ~/.cache
+path, the /dev/dri/by-path device directory, or a repo-relative asset.
+Absolute host paths are blocked. This script mirrors that gate so a registry
+change that would silently block recipes in the plugin fails CI here instead.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DIGEST_PINNED = re.compile(r"@sha256:[0-9a-f]{64}$")
+REVISION_PINNED = re.compile(r"^[0-9a-f]{40,64}$")
+FORBIDDEN_ARGUMENT = re.compile(r"enforce.eager|disable.?cuda.?graph", re.IGNORECASE)
+PLACEHOLDER_MOUNT = re.compile(r"^\$\{(MODEL_ROOT|CACHE_ROOT)\}/[^\0]+$")
+
+
+def load(path, errors):
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        errors.append(f"{path}: unreadable record: {error}")
+        return None
+
+
+def check_mount_source(identifier, source, root, errors):
+    if not isinstance(source, str) or not source:
+        errors.append(f"{identifier}: mount has no source")
+        return
+    if ".." in source:
+        errors.append(f"{identifier}: mount source escapes its boundary: {source}")
+        return
+    if PLACEHOLDER_MOUNT.fullmatch(source):
+        return
+    if source.startswith("~/.cache/"):
+        return
+    if source == "/dev/dri/by-path":
+        return
+    if source.startswith(("/", "~")):
+        errors.append(f"{identifier}: plugin blocks absolute mount source {source}")
+        return
+    asset = (root / source).resolve()
+    if root.resolve() not in asset.parents or not asset.is_file():
+        errors.append(f"{identifier}: mount source is not a registry asset: {source}")
+
+
+def check_recipe(root, recipe, errors):
+    identifier = recipe.get("id")
+    launch = recipe.get("launch") or {}
+
+    instance = load(root / "model-instance" / f"{recipe.get('model_instance_id')}.json", errors)
+    if instance is None:
+        return
+    if load(root / "model" / f"{instance.get('model_id')}.json", errors) is None:
+        return
+    if load(root / "hardware" / f"{recipe.get('hardware_id')}.json", errors) is None:
+        return
+
+    if not DIGEST_PINNED.search(launch.get("image") or ""):
+        errors.append(f"{identifier}: plugin gate requires a digest-pinned image")
+    if not REVISION_PINNED.fullmatch(instance.get("revision") or ""):
+        errors.append(f"{identifier}: plugin gate requires a pinned model revision")
+    if not isinstance(launch.get("container_port"), int):
+        errors.append(f"{identifier}: plugin gate requires a numeric container_port")
+    for argument in launch.get("arguments") or []:
+        if isinstance(argument, str) and FORBIDDEN_ARGUMENT.search(argument):
+            errors.append(f"{identifier}: plugin gate forbids launch argument {argument!r}")
+    for mount in launch.get("mounts") or []:
+        check_mount_source(identifier, (mount or {}).get("source"), root, errors)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", nargs="?", default="registry")
+    args = parser.parse_args()
+    root = Path(args.root)
+
+    errors = []
+    checked = 0
+    for path in sorted((root / "recipe").glob("*.json")):
+        recipe = load(path, errors)
+        if not recipe or recipe.get("status") != "validated":
+            continue
+        if (recipe.get("launch") or {}).get("kind") != "docker":
+            continue
+        checked += 1
+        check_recipe(root, recipe, errors)
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        raise SystemExit(1)
+    print(f"plugin gate clean: {checked} validated docker recipes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- **registry/recipe/glm52-exl3-rtxpro6000-vllm-tp4.json** — replaced the absolute host mounts (`/mnt/llm_models/GLM-5.2-EXL3-TR3-3.0bpw`, `/mnt/llm_models/cache_glm52_exl3_text`) with the `${MODEL_ROOT}/…` and `${CACHE_ROOT}/…` placeholder convention the glm53-flash recipes already follow. The Omarchy local-ai plugin (basecamp/omarchy PR #8836) interpolates these placeholders and blocks absolute mount sources, so the recipe showed as blocked.
- **scripts/check_plugin_gate.py** — new CI check that mirrors the plugin's acceptance gate over every validated Docker recipe: record-chain resolution (recipe → model-instance → model, hardware), digest-pinned image, pinned model revision (40–64 hex), numeric `container_port`, no `enforce-eager`/`disable-cuda-graph` arguments, and portable mount sources (`${MODEL_ROOT}`/`${CACHE_ROOT}` placeholders, `~/.cache/…`, `/dev/dri/by-path`, or in-registry assets — absolute host paths rejected).
- **Makefile / .github/workflows/ci.yml** — the gate runs as `make plugin-gate`, is part of `make check`, and has its own CI step, so schema/layout changes (like the index.json sharding in 0ecc067) can't silently break the plugin again.

## Verification

- `python3 scripts/check_plugin_gate.py` → `plugin gate clean: 34 validated docker recipes`
- Negative test: reverting one mount to `/mnt/…` fails with `plugin blocks absolute mount source /mnt/llm_models/GLM-5.2-EXL3-TR3-3.0bpw` (exit 1)
- `make check` passes end to end (format, validate, plugin-gate, 37 node tests, typecheck, generated types and index shards unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)