### PR TITLE
Compare: FP4 column + bandwidth-range rendering fix

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic"
 
 export const metadata: Metadata = { title: "Compare hardware · Local AI Registry" }
 
-type SortKey = "name" | "vram" | "bandwidth" | "fp16" | "fp8" | "int8" | "price" | "recipes"
+type SortKey = "name" | "vram" | "bandwidth" | "fp16" | "fp8" | "fp4" | "int8" | "price" | "recipes"
 
 const COLUMNS: Array<{ key: SortKey; label: string }> = [
   { key: "name", label: "Hardware" },
@@ -16,6 +16,7 @@ const COLUMNS: Array<{ key: SortKey; label: string }> = [
   { key: "bandwidth", label: "Bandwidth" },
   { key: "fp16", label: "FP16 TFLOPS" },
   { key: "fp8", label: "FP8 TFLOPS" },
+  { key: "fp4", label: "FP4 TFLOPS" },
   { key: "int8", label: "INT8 TOPS" },
   { key: "price", label: "Lowest new (US)" },
   { key: "recipes", label: "Recipes" },
@@ -24,9 +25,10 @@ const COLUMNS: Array<{ key: SortKey; label: string }> = [
 function metric(row: HardwareComparisonRow, key: SortKey): number | string | null {
   if (key === "name") return row.name
   if (key === "vram") return row.vram_gb
-  if (key === "bandwidth") return row.bandwidth_gb_per_s
+  if (key === "bandwidth") return typeof row.bandwidth_gb_per_s === "object" && row.bandwidth_gb_per_s !== null ? row.bandwidth_gb_per_s.max : row.bandwidth_gb_per_s
   if (key === "fp16") return row.fp16_tflops
   if (key === "fp8") return row.fp8_tflops
+  if (key === "fp4") return row.fp4_tflops
   if (key === "int8") return row.int8_tflops
   if (key === "price") return row.lowest_new_usd
   return row.recipe_count
@@ -35,6 +37,12 @@ function metric(row: HardwareComparisonRow, key: SortKey): number | string | nul
 function cell(value: number | null, sparse = false): string {
   if (value === null) return "—"
   return `${value.toLocaleString("en-US")}${sparse ? " *" : ""}`
+}
+
+function bandwidth(value: HardwareComparisonRow["bandwidth_gb_per_s"]): string {
+  if (value === null) return "—"
+  if (typeof value === "object") return `${value.min.toLocaleString("en-US")}–${value.max.toLocaleString("en-US")} GB/s`
+  return `${value.toLocaleString("en-US")} GB/s`
 }
 
 export default async function ComparePage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
@@ -92,9 +100,10 @@ export default async function ComparePage({ searchParams }: { searchParams: Prom
               <tr key={row.id}>
                 <td><Link href={`/hardware/${row.id}`}>{row.name}</Link></td>
                 <td>{row.vram_gb.toLocaleString("en-US")} GB</td>
-                <td>{row.bandwidth_gb_per_s === null ? "—" : `${row.bandwidth_gb_per_s.toLocaleString("en-US")} GB/s`}</td>
+                <td>{bandwidth(row.bandwidth_gb_per_s)}</td>
                 <td>{cell(row.fp16_tflops, row.fp16_sparse)}</td>
                 <td>{cell(row.fp8_tflops, row.fp8_sparse)}</td>
+                <td>{cell(row.fp4_tflops, row.fp4_sparse)}</td>
                 <td>{cell(row.int8_tflops, row.int8_sparse)}</td>
                 <td>{row.lowest_new_usd === null ? "—" : `$${row.lowest_new_usd.toLocaleString("en-US", { maximumFractionDigits: 0 })}`}</td>
                 <td>{row.recipe_count.toLocaleString("en-US")}</td>

--- a/app/lib/record-view.ts
+++ b/app/lib/record-view.ts
@@ -177,7 +177,15 @@ export function recordFacts(collection: string, record: Record<string, unknown>)
       fact("Backend", record.accelerator_backend),
       fact("VRAM", memory?.vram_gb === undefined ? null : `${memory.vram_gb} GB`),
       fact("Memory type", memory?.vram_type),
-      fact("Bandwidth", memory?.bandwidth_gb_per_s === undefined ? null : `${memory.bandwidth_gb_per_s} GB/s`),
+      fact("Bandwidth", (() => {
+        const bandwidth = memory?.bandwidth_gb_per_s
+        if (bandwidth === undefined || bandwidth === null) return null
+        if (typeof bandwidth === "object") {
+          const range = bandwidth as { min?: number; max?: number }
+          return `${range.min ?? "?"}–${range.max ?? "?"} GB/s`
+        }
+        return `${bandwidth} GB/s`
+      })()),
     ].filter((item): item is RecordFact => item !== null)
   }
   if (collection === "models") {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -268,17 +268,21 @@ export function getHardwareMarket(hardwareId: string): RegionMarket[] {
   return rows.sort((left, right) => left.region.localeCompare(right.region))
 }
 
+export type BandwidthRange = { min: number; max: number }
+
 export type HardwareComparisonRow = {
   id: string
   name: string
   vendor: string
   vram_gb: number
-  bandwidth_gb_per_s: number | null
+  bandwidth_gb_per_s: number | BandwidthRange | null
   fp16_tflops: number | null
   fp8_tflops: number | null
+  fp4_tflops: number | null
   int8_tflops: number | null
   fp16_sparse: boolean
   fp8_sparse: boolean
+  fp4_sparse: boolean
   int8_sparse: boolean
   lowest_new_usd: number | null
   price_observed_at: string | null
@@ -301,6 +305,7 @@ export function hardwareComparison(): HardwareComparisonRow[] {
   return [...data.hardware.values()].map((record) => {
     const fp16 = bestThroughput(record, "fp16")
     const fp8 = bestThroughput(record, "fp8")
+    const fp4 = bestThroughput(record, "fp4")
     const int8 = bestThroughput(record, "int8")
     const market = getHardwareMarket(record.id)
     const us = market.find((row) => row.region === "US" && row.lowest_new !== null)
@@ -309,12 +314,14 @@ export function hardwareComparison(): HardwareComparisonRow[] {
       name: record.name,
       vendor: record.vendor,
       vram_gb: record.memory.vram_gb,
-      bandwidth_gb_per_s: record.memory.bandwidth_gb_per_s as number | null,
+      bandwidth_gb_per_s: record.memory.bandwidth_gb_per_s as number | BandwidthRange | null,
       fp16_tflops: fp16.value,
       fp8_tflops: fp8.value,
+      fp4_tflops: fp4.value,
       int8_tflops: int8.value,
       fp16_sparse: fp16.sparse,
       fp8_sparse: fp8.sparse,
+      fp4_sparse: fp4.sparse,
       int8_sparse: int8.sparse,
       lowest_new_usd: us?.lowest_new ?? null,
       price_observed_at: us?.observed_at ?? null,

--- a/registry/recipe/glm53-flash-exl3-tr3-4bpw-dflash2-rtxpro6000-vllm-tp2.json
+++ b/registry/recipe/glm53-flash-exl3-tr3-4bpw-dflash2-rtxpro6000-vllm-tp2.json
@@ -110,14 +110,14 @@
         "target": "/model"
       },
       {
-        "read_only": true,
-        "source": "${MODEL_ROOT}/GLM-5.3-Flash-DFlash2",
-        "target": "/draft",
         "provision": {
           "repository": "incoai/GLM-5.3-Flash-DFlash2",
           "revision": "bf582e4eacc1810f76656d1811693ff6c6737d2a",
           "size_gb": 2.2
-        }
+        },
+        "read_only": true,
+        "source": "${MODEL_ROOT}/GLM-5.3-Flash-DFlash2",
+        "target": "/draft"
       },
       {
         "read_only": false,

--- a/registry/recipe/glm53-flash-exl3-tr3-4bpw-dflash2-rtxpro6000-vllm-tp4.json
+++ b/registry/recipe/glm53-flash-exl3-tr3-4bpw-dflash2-rtxpro6000-vllm-tp4.json
@@ -113,14 +113,14 @@
         "target": "/model"
       },
       {
-        "read_only": true,
-        "source": "${MODEL_ROOT}/GLM-5.3-Flash-DFlash2",
-        "target": "/draft",
         "provision": {
           "repository": "incoai/GLM-5.3-Flash-DFlash2",
           "revision": "bf582e4eacc1810f76656d1811693ff6c6737d2a",
           "size_gb": 2.2
-        }
+        },
+        "read_only": true,
+        "source": "${MODEL_ROOT}/GLM-5.3-Flash-DFlash2",
+        "target": "/draft"
       },
       {
         "read_only": false,


### PR DESCRIPTION
Fixes the `[object Object] GB/s` cells (Apple chips carry legitimate {min,max} bandwidth ranges — now rendered as `300–400 GB/s`, sorted by max) and adds the FP4 TFLOPS column to /compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)