### PR TITLE
Weekly data refresh: prices + downloads (2026-08-31)

### DIFF
--- a/registry/model/beaglesempra-7b.json
+++ b/registry/model/beaglesempra-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/bonsai-27b.json
+++ b/registry/model/bonsai-27b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/cogvlm2-llama3-chat-19b.json
+++ b/registry/model/cogvlm2-llama3-chat-19b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/deepseek.json
+++ b/registry/model/deepseek.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/diffusiongemma-26b-a4b.json
+++ b/registry/model/diffusiongemma-26b-a4b.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/dpopenhermes-7b-v2.json
+++ b/registry/model/dpopenhermes-7b-v2.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/dpopenhermes-7b.json
+++ b/registry/model/dpopenhermes-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/dr-samantha-7b.json
+++ b/registry/model/dr-samantha-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-11b.json
+++ b/registry/model/falcon-11b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-e-1b-base.json
+++ b/registry/model/falcon-e-1b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-e-1b-instruct.json
+++ b/registry/model/falcon-e-1b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-e-3b-base-prequantized.json
+++ b/registry/model/falcon-e-3b-base-prequantized.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-e-3b-base.json
+++ b/registry/model/falcon-e-3b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-e-3b-instruct.json
+++ b/registry/model/falcon-e-3b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-0-5b-base.json
+++ b/registry/model/falcon-h1-0-5b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-0-5b-instruct.json
+++ b/registry/model/falcon-h1-0-5b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-1-5b-base.json
+++ b/registry/model/falcon-h1-1-5b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-1-5b-deep-base.json
+++ b/registry/model/falcon-h1-1-5b-deep-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-1-5b-deep-instruct.json
+++ b/registry/model/falcon-h1-1-5b-deep-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-1-5b-instruct.json
+++ b/registry/model/falcon-h1-1-5b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-34b-base.json
+++ b/registry/model/falcon-h1-34b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-34b-instruct.json
+++ b/registry/model/falcon-h1-34b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-3b-base.json
+++ b/registry/model/falcon-h1-3b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-3b-instruct.json
+++ b/registry/model/falcon-h1-3b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-7b-base.json
+++ b/registry/model/falcon-h1-7b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-h1-7b-instruct.json
+++ b/registry/model/falcon-h1-7b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-mamba-7b-instruct.json
+++ b/registry/model/falcon-mamba-7b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon-mamba-7b.json
+++ b/registry/model/falcon-mamba-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/falcon3-10b-base.json
+++ b/registry/model/falcon3-10b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/gemma-4-12b-q4km.json
+++ b/registry/model/gemma-4-12b-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/gemma-4-31b-v2.json
+++ b/registry/model/gemma-4-31b-v2.json
@@ -3,7 +3,7 @@
   "architecture": "dense",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/gemma-4-e4b.json
+++ b/registry/model/gemma-4-e4b.json
@@ -3,7 +3,7 @@
   "architecture": "dense",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-4-32b-0414.json
+++ b/registry/model/glm-4-32b-0414.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-4-32b-base-0414.json
+++ b/registry/model/glm-4-32b-base-0414.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-4-7.json
+++ b/registry/model/glm-4-7.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-4-9b-hf.json
+++ b/registry/model/glm-4-9b-hf.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-4-9b.json
+++ b/registry/model/glm-4-9b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/glm-5.json
+++ b/registry/model/glm-5.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/holo-3-1-35b-a3b.json
+++ b/registry/model/holo-3-1-35b-a3b.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/hunyuan-7b-pretrain.json
+++ b/registry/model/hunyuan-7b-pretrain.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/hunyuan-a13b-instruct.json
+++ b/registry/model/hunyuan-a13b-instruct.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/kimi-k2-5.json
+++ b/registry/model/kimi-k2-5.json
@@ -3,7 +3,7 @@
   "architecture": "dense",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/llama-3-1-nemotron-70b-q4km.json
+++ b/registry/model/llama-3-1-nemotron-70b-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/llama-3-3-70b-instruct-q4km.json
+++ b/registry/model/llama-3-3-70b-instruct-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/nemotron-3-5-asr-streaming-0-6b.json
+++ b/registry/model/nemotron-3-5-asr-streaming-0-6b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/nemotron-cascade-2-30b-a3b.json
+++ b/registry/model/nemotron-cascade-2-30b-a3b.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/nvidia-nemotron-3-5.json
+++ b/registry/model/nvidia-nemotron-3-5.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/nvidia-nemotron-3-super-120b-a12b.json
+++ b/registry/model/nvidia-nemotron-3-super-120b-a12b.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/openchat-3-5-0106.json
+++ b/registry/model/openchat-3-5-0106.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/openchat-3-5-1210.json
+++ b/registry/model/openchat-3-5-1210.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/openhermes-2-5-mistral-7b.json
+++ b/registry/model/openhermes-2-5-mistral-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/orca-mini-v3-13b.json
+++ b/registry/model/orca-mini-v3-13b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/orca-mini-v3-70b.json
+++ b/registry/model/orca-mini-v3-70b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/orca-mini-v3-7b.json
+++ b/registry/model/orca-mini-v3-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/parakeet-ctc-1-1b.json
+++ b/registry/model/parakeet-ctc-1-1b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/parakeet-rnnt-0-6b.json
+++ b/registry/model/parakeet-rnnt-0-6b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/parakeet-tdt-0-6b-v3.json
+++ b/registry/model/parakeet-tdt-0-6b-v3.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen2-5-72b-instruct-q4km.json
+++ b/registry/model/qwen2-5-72b-instruct-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen2-5-7b.json
+++ b/registry/model/qwen2-5-7b.json
@@ -3,7 +3,7 @@
   "architecture": "dense",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen2-72b-instruct-q4km.json
+++ b/registry/model/qwen2-72b-instruct-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-235b-a22b-ud-q3kxl.json
+++ b/registry/model/qwen3-235b-a22b-ud-q3kxl.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-32b.json
+++ b/registry/model/qwen3-32b.json
@@ -3,7 +3,7 @@
   "architecture": "dense",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-5-35b-a3b.json
+++ b/registry/model/qwen3-5-35b-a3b.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-6-35b-a3b-ud-iq2xxs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq2xxs.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-6-35b-a3b-ud-iq3xxs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq3xxs.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-6-35b-a3b-ud-iq4xs.json
+++ b/registry/model/qwen3-6-35b-a3b-ud-iq4xs.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3-8-27b-ud-q4km.json
+++ b/registry/model/qwen3-8-27b-ud-q4km.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/qwen3.json
+++ b/registry/model/qwen3.json
@@ -3,7 +3,7 @@
   "architecture": "moe",
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/rocket-3b.json
+++ b/registry/model/rocket-3b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/smol-7b.json
+++ b/registry/model/smol-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/speechless-llama2-13b.json
+++ b/registry/model/speechless-llama2-13b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/speechless-mistral-7b-dare-0-85.json
+++ b/registry/model/speechless-mistral-7b-dare-0-85.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/speechless-mistral-dolphin-orca-platypus-samantha-7b.json
+++ b/registry/model/speechless-mistral-dolphin-orca-platypus-samantha-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/speechless-mistral-moloras-7b.json
+++ b/registry/model/speechless-mistral-moloras-7b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/stablelm-zephyr-3b.json
+++ b/registry/model/stablelm-zephyr-3b.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/tenyxchat-7b-v1.json
+++ b/registry/model/tenyxchat-7b-v1.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-base.json
+++ b/registry/model/whisper-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-large-v2.json
+++ b/registry/model/whisper-large-v2.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-large-v3-turbo.json
+++ b/registry/model/whisper-large-v3-turbo.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-large-v3.json
+++ b/registry/model/whisper-large-v3.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-medium.json
+++ b/registry/model/whisper-medium.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-small.json
+++ b/registry/model/whisper-small.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/whisper-tiny.json
+++ b/registry/model/whisper-tiny.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/model/youtu-llm-2b-base.json
+++ b/registry/model/youtu-llm-2b-base.json
@@ -3,7 +3,7 @@
   "architecture": null,
   "downloads": {
     "all_time": null,
-    "captured_at": "2026-08-31T15:38:41Z",
+    "captured_at": "2026-08-31T20:59:16Z",
     "last_30d": null,
     "source": "huggingface-api"
   },

--- a/registry/price/dgx-spark/us.json
+++ b/registry/price/dgx-spark/us.json
@@ -8,6 +8,17 @@
   "id": "dgx-spark--us",
   "observations": [
     {
+      "amount": 4999.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "bhphotovideo",
+      "title": "NVIDIA DGX Spark Founders Edition 940-54242-0000-000",
+      "url": "https://www.bhphotovideo.com/c/product/1927297-REG/nvidia_940_54242_0000_000_dgx_spark_founders_edition.html"
+    },
+    {
       "amount": 4699.99,
       "condition": "new",
       "currency": "USD",
@@ -19,15 +30,15 @@
       "url": "https://www.microcenter.com/product/699008/nvidia-dgx-spark"
     }
   ],
-  "observed_at": "2026-08-31T12:11:18Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "dgx-spark",
     "name": "NVIDIA DGX Spark"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -38,14 +49,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 1,
+    "listing_count": 2,
     "lowest_new": 4699.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 1,
     "state": "candidate"
   }

--- a/registry/price/intel-arc-pro-b60/us.json
+++ b/registry/price/intel-arc-pro-b60/us.json
@@ -11,6 +11,17 @@
       "amount": 649.99,
       "condition": "new",
       "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "microcenter",
+      "title": "ASRock Intel Arc Pro B60 Creator Single-Fan AI & Workstation Graphics Card; 24GB GDDR6 Memory",
+      "url": "https://www.microcenter.com/product/704236/asrock-intel-arc-pro-b60-creator-single-fan-ai-workstation-graphics-card"
+    },
+    {
+      "amount": 649.99,
+      "condition": "new",
+      "currency": "USD",
       "in_stock": true,
       "observed_at": "2026-08-31T12:11:18Z",
       "quantity": null,
@@ -30,15 +41,15 @@
       "url": "https://www.newegg.com/gunnir-intel-arc-pro-b60-bs-24g-24gb-video-cards-turbo-fan-cooling-system/p/3GM-0001-00029"
     }
   ],
-  "observed_at": "2026-08-31T12:11:18Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "intel-arc-pro-b60",
     "name": "Intel Arc Pro b60"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -49,15 +60,15 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 2,
-    "listing_count": 2,
+    "listing_count": 3,
     "lowest_new": 649.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
-    "rejected_observations": 0,
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
+    "rejected_observations": 1,
     "state": "candidate"
   }
 }

--- a/registry/price/intel-arc-pro-b70/de.json
+++ b/registry/price/intel-arc-pro-b70/de.json
@@ -8,6 +8,17 @@
   "id": "intel-arc-pro-b70--de",
   "observations": [
     {
+      "amount": 1672.0,
+      "condition": "new",
+      "currency": "EUR",
+      "in_stock": true,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "alternate",
+      "title": "ASRock Intel® Arc Pro B70 Creator 32GB B70 CL, Grafikkarte 4x DisplayPort",
+      "url": "https://www.alternate.de/ASRock/Intel-Arc-Pro-B70-Creator-32GB-B70-CL-Grafikkarte/html/product/100198958"
+    },
+    {
       "amount": 1851.11,
       "condition": "new",
       "currency": "EUR",
@@ -19,15 +30,15 @@
       "url": "https://www.cyberport.de/pc-und-zubehoer/komponenten/grafikkarten.html/pdp/2E25-153/Intel-Arc-Pro-B70-32GB-GDDR6-Grafikkarte-4x-DP.html"
     }
   ],
-  "observed_at": "2026-08-31T12:11:02Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "intel-arc-pro-b70",
     "name": "Intel Arc Pro b70"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -37,15 +48,15 @@
   },
   "schema_version": "local-ai-registry/v1",
   "summary": {
-    "in_stock_count": 1,
-    "listing_count": 1,
-    "lowest_new": 1851.11,
+    "in_stock_count": 2,
+    "listing_count": 2,
+    "lowest_new": 1672.0,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/intel-arc-pro-b70/us.json
+++ b/registry/price/intel-arc-pro-b70/us.json
@@ -12,6 +12,28 @@
       "condition": "new",
       "currency": "USD",
       "in_stock": true,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "bhphotovideo",
+      "title": "Intel Arc Pro B70 Graphics Card 33P01IB0BB",
+      "url": "https://www.bhphotovideo.com/c/product/1959142-REG/intel_33p01ib0bb_arc_pro_b70_32gb.html"
+    },
+    {
+      "amount": 1699.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "Intel Arc Pro B70 32GB 256-bit GDDR6 PCI Express 5.0 x16, 32 Ray Tracing Units, 32 Xe Cores, AI and Workstation Graphics Card",
+      "url": "https://www.newegg.com/intel-arc-pro-b70-32gb-graphics-card/p/N82E16814883008"
+    },
+    {
+      "amount": 1699.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": true,
       "observed_at": "2026-08-31T11:49:17.000Z",
       "quantity": null,
       "retailer": "newegg",
@@ -19,15 +41,15 @@
       "url": "https://www.newegg.com/intel-arc-pro-b70-32gb-graphics-card/p/N82E16814883008?Item=N82E16814883008"
     }
   ],
-  "observed_at": "2026-08-31T11:49:17.000Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "intel-arc-pro-b70",
     "name": "Intel Arc Pro b70"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:12:00.000Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 200
   },
   "region": {
@@ -37,15 +59,15 @@
   },
   "schema_version": "local-ai-registry/v1",
   "summary": {
-    "in_stock_count": 1,
-    "listing_count": 1,
+    "in_stock_count": 2,
+    "listing_count": 3,
     "lowest_new": 1699.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/radeon-ai-pro-r9700/us.json
+++ b/registry/price/radeon-ai-pro-r9700/us.json
@@ -8,6 +8,17 @@
   "id": "radeon-ai-pro-r9700--us",
   "observations": [
     {
+      "amount": 1359.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "bhphotovideo",
+      "title": "ASUS Turbo Radeon AI Pro R9700 Graphics TURBO-AI-PRO-R9700-32G",
+      "url": "https://www.bhphotovideo.com/c/product/1928519-REG/asus_turbo_ai_pro_r9700_32g_turbo_radeon_ai_pro.html"
+    },
+    {
       "amount": 1679.99,
       "condition": "new",
       "currency": "USD",
@@ -30,15 +41,15 @@
       "url": "https://www.newegg.com/sapphire-tech-32358-01-20g-radeon-ai-pro-r9700-32gb-graphics-card/p/N82E16814202462"
     }
   ],
-  "observed_at": "2026-08-31T12:11:18Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "radeon-ai-pro-r9700",
     "name": "Radeon AI Pro r9700"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -49,15 +60,15 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 2,
+    "listing_count": 3,
     "lowest_new": 1299.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 2
+    "retailer_count": 3
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
-    "rejected_observations": 0,
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
+    "rejected_observations": 1,
     "state": "candidate"
   }
 }

--- a/registry/price/rtx-2000-ada/de.json
+++ b/registry/price/rtx-2000-ada/de.json
@@ -17,17 +17,28 @@
       "retailer": "MediaMarkt",
       "title": "NVIDIA RTX 2000 Ada 16 GB GDDR6 (NVIDIA, Grafikkarte)",
       "url": "https://www.mediamarkt.de/de/product/_nvidia-rtx-2000-ada-16-gb-gddr6-nvidia-grafikkarte-159172187.html"
+    },
+    {
+      "amount": 641.28,
+      "condition": "new",
+      "currency": "EUR",
+      "in_stock": true,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "mindfactory",
+      "title": "16GB NVIDIA RTX 2000 Ada Generation Aktiv PCIe 4.0 x16 (x8) Retail",
+      "url": "https://www.mindfactory.de/product_info.php/16GB-NVIDIA-RTX-2000-Ada-Generation-Aktiv-PCIe-4-0-x16--x8-Retail-_1578800.html"
     }
   ],
-  "observed_at": "2026-08-31T11:49:41.803Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-2000-ada",
     "name": "RTX 2000 ada"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:12:00.000Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 200
   },
   "region": {
@@ -37,15 +48,15 @@
   },
   "schema_version": "local-ai-registry/v1",
   "summary": {
-    "in_stock_count": 1,
-    "listing_count": 1,
-    "lowest_new": 714.03,
+    "in_stock_count": 2,
+    "listing_count": 2,
+    "lowest_new": 641.28,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-2000-ada/us.json
+++ b/registry/price/rtx-2000-ada/us.json
@@ -11,23 +11,45 @@
       "amount": 849.0,
       "condition": "new",
       "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "bhphotovideo",
+      "title": "NVIDIA RTX 2000 Ada Generation Graphics Card",
+      "url": "https://www.bhphotovideo.com/c/product/1882047-REG/nvidia_900_5g192_2240_000_rtx_2000_ada_graphic.html"
+    },
+    {
+      "amount": 849.0,
+      "condition": "new",
+      "currency": "USD",
       "in_stock": true,
       "observed_at": "2026-08-31T12:11:18Z",
       "quantity": null,
       "retailer": "bhphotovideo",
       "title": "PNY NVIDIA RTX 2000 Ada Generation Graphics Card",
       "url": "https://www.bhphotovideo.com/c/replacement_for/1882047-REG/nvidia_900_5g192_2240_000_rtx_2000_ada_graphic.html"
+    },
+    {
+      "amount": 849.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "PNY RTX 2000E ADA VCNRTX2000ADAS-LLP 16GB 128-bit GDDR6 PCI Express 4.0 x8 Graphics Card",
+      "url": "https://www.newegg.com/pny-technologies-inc-vcnrtx2000adas-llp-rtx-2000e-ada-16gb-graphics-card/p/N82E16814133896"
     }
   ],
-  "observed_at": "2026-08-31T12:11:18Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-2000-ada",
     "name": "RTX 2000 ada"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -38,14 +60,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 1,
+    "listing_count": 3,
     "lowest_new": 849.0,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-3070-ti/us.json
+++ b/registry/price/rtx-3070-ti/us.json
@@ -8,6 +8,17 @@
   "id": "rtx-3070-ti--us",
   "observations": [
     {
+      "amount": 599.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "bestbuy",
+      "title": "NVIDIA GeForce RTX 3070 Ti 8GB GDDR6X PCI Express 4.0 Graphics Card Dark Platinum and Black 900-1G143-2515-000",
+      "url": "https://www.bestbuy.com/site/nvidia-geforce-rtx-3070-ti-8gb-gddr6x-pci-express-4-0-graphics-card-dark-platinum-and-black/6465789.p?skuId=6465789"
+    },
+    {
       "amount": 349.99,
       "condition": "refurbished",
       "currency": "USD",
@@ -17,17 +28,28 @@
       "retailer": "microcenter",
       "title": "NVIDIA GeForce RTX 3070 Ti Founders Edition Dual-Fan 8GB GDDR6X PCIe 4.0 Graphics Card (Refurbished)",
       "url": "https://www.microcenter.com/product/672331"
+    },
+    {
+      "amount": 689.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "NVIDIA GeForce RTX 3070 Ti Founders Edition Graphics Card 8GB GDDR6X - Titanium and Black",
+      "url": "https://www.newegg.com/nvidia-founders-edition-900-1g143-2515-000-geforce-rtx-3070-ti-8gb-graphics-card/p/N82E16814132097"
     }
   ],
-  "observed_at": "2026-08-31T12:11:03Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-3070-ti",
     "name": "RTX 3070 ti"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -38,14 +60,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 0,
-    "listing_count": 1,
-    "lowest_new": null,
+    "listing_count": 3,
+    "lowest_new": 599.99,
     "lowest_refurbished": 349.99,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 3
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-4060-ti/us.json
+++ b/registry/price/rtx-4060-ti/us.json
@@ -12,15 +12,26 @@
   "id": "rtx-4060-ti--us",
   "observations": [
     {
-      "amount": 469.99,
-      "condition": "refurbished",
+      "amount": 639.99,
+      "condition": "new",
       "currency": "USD",
-      "in_stock": true,
-      "observed_at": "2026-08-31T12:11:10Z",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
       "quantity": null,
       "retailer": "newegg",
-      "title": "Refurbished ASUS Dual GeForce RTX 4060 Ti 16GB GDDR6",
-      "url": "https://www.newegg.com/p/pl?N=100007709+601408880&Submit=property&n=100007709+601408880&submit=property"
+      "title": "ASUS Dual GeForce RTX 4060 Ti EVO OC Edition 8GB GDDR6",
+      "url": "https://www.newegg.com/asus-dual-rtx4060ti-o8g-evo-nvidia-geforce-rtx-4060-ti-8gb-gddr6/p/N82E16814126717"
+    },
+    {
+      "amount": 659.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "MSI Ventus GeForce RTX 4060 Ti Graphics Card RTX 4060 Ti VENTUS 2X BLACK 8G OC",
+      "url": "https://www.newegg.com/msi-rtx-4060-ti-ventus-2x-black-8g-oc-geforce-rtx-4060-ti-8gb-graphics-card-double-fans/p/N82E16814137799"
     },
     {
       "amount": 499.0,
@@ -32,17 +43,28 @@
       "retailer": "newegg",
       "title": "ZOTAC GAMING GeForce RTX 4060 Ti 8GB Twin Edge OC White Edition",
       "url": "https://www.newegg.com/p/pl?N=100007709&d=rtx+4060+ti&isdeptsrh=1"
+    },
+    {
+      "amount": 469.99,
+      "condition": "refurbished",
+      "currency": "USD",
+      "in_stock": true,
+      "observed_at": "2026-08-31T12:11:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "Refurbished ASUS Dual GeForce RTX 4060 Ti 16GB GDDR6",
+      "url": "https://www.newegg.com/p/pl?N=100007709+601408880&Submit=property&n=100007709+601408880&submit=property"
     }
   ],
-  "observed_at": "2026-08-31T12:11:10Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-4060-ti",
     "name": "RTX 4060 ti"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -53,14 +75,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 2,
-    "listing_count": 2,
+    "listing_count": 4,
     "lowest_new": 499.0,
     "lowest_refurbished": 469.99,
     "lowest_used": null,
     "retailer_count": 1
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-4060/us.json
+++ b/registry/price/rtx-4060/us.json
@@ -17,17 +17,28 @@
       "retailer": "newegg",
       "title": "MSI Ventus GeForce RTX 4060 8GB GDDR6 PCI Express 4.0 x8 ATX Graphics Card RTX 4060 VENTUS 2X BLACK 8G OC",
       "url": "https://www.newegg.com/p/pl?N=100007709+600030348+601408876"
+    },
+    {
+      "amount": 569.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "Yeston RTX 4060 8GB GDDR6 Graphics Card",
+      "url": "https://www.newegg.com/yeston-rtx-4060-rtx4060-8g-8gb-graphics-card-double-fans/p/1FT-007N-000B4"
     }
   ],
-  "observed_at": "2026-08-31T12:11:03Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-4060",
     "name": "RTX 4060"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -38,14 +49,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 1,
+    "listing_count": 2,
     "lowest_new": 499.0,
     "lowest_refurbished": null,
     "lowest_used": null,
     "retailer_count": 1
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-4070-ti-super/us.json
+++ b/registry/price/rtx-4070-ti-super/us.json
@@ -8,15 +8,26 @@
   "id": "rtx-4070-ti-super--us",
   "observations": [
     {
-      "amount": 829.99,
-      "condition": "refurbished",
+      "amount": 1301.74,
+      "condition": "new",
       "currency": "USD",
-      "in_stock": true,
-      "observed_at": "2026-08-31T12:11:10Z",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
       "quantity": null,
       "retailer": "newegg",
-      "title": "Refurbished MSI Ventus GeForce RTX 4070 Ti SUPER 16G VENTUS 2X WHITE OC",
-      "url": "https://www.newegg.com/p/pl?Order=1&d=4070+ti&page=1"
+      "title": "GIGABYTE GeForce RTX 4070 Ti SUPER WINDFORCE OC 16G Graphics Card",
+      "url": "https://newegg.com/gigabyte-geforce-rtx-4070-ti-super-gv-n407tswf3oc-16gd/p/N82E16814932678"
+    },
+    {
+      "amount": 1319.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "ASUS TUF RTX 4070 Ti SUPER Gaming Graphics Card",
+      "url": "https://www.newegg.com/asus-tuf-gaming-tuf-rtx4070tis-o16g-gaming-geforce-rtx-4070-ti-super-16gb-graphics-card-triple-fans/p/N82E16814126685"
     },
     {
       "amount": 1265.85,
@@ -28,17 +39,28 @@
       "retailer": "newegg",
       "title": "MSI Gaming GeForce RTX 4070 Ti SUPER 16G GAMING X SLIM",
       "url": "https://www.newegg.com/p/pl?N=100007709&d=rtx+4070+ti+refurb&isdeptsrh=1"
+    },
+    {
+      "amount": 829.99,
+      "condition": "refurbished",
+      "currency": "USD",
+      "in_stock": true,
+      "observed_at": "2026-08-31T12:11:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "Refurbished MSI Ventus GeForce RTX 4070 Ti SUPER 16G VENTUS 2X WHITE OC",
+      "url": "https://www.newegg.com/p/pl?Order=1&d=4070+ti&page=1"
     }
   ],
-  "observed_at": "2026-08-31T12:11:10Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-4070-ti-super",
     "name": "RTX 4070 ti super"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -49,14 +71,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 2,
-    "listing_count": 2,
+    "listing_count": 4,
     "lowest_new": 1265.85,
     "lowest_refurbished": 829.99,
     "lowest_used": null,
     "retailer_count": 1
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-4080-super/us.json
+++ b/registry/price/rtx-4080-super/us.json
@@ -8,6 +8,17 @@
   "id": "rtx-4080-super--us",
   "observations": [
     {
+      "amount": 1950.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "NVIDIA GeForce RTX 4080 SUPER Founders Edition Graphics Card 16GB GDDR6X - Titanium and Black",
+      "url": "https://www.newegg.com/nvidia-founders-edition-900-1g136-2555-000-geforce-rtx-4080-super-16gb-graphics-card/p/1FT-0004-008P3"
+    },
+    {
       "amount": 1522.0,
       "condition": "new",
       "currency": "USD",
@@ -30,15 +41,15 @@
       "url": "https://www.newegg.com/p/pl?d=rtx+4080+super+gpu"
     }
   ],
-  "observed_at": "2026-08-31T12:11:10Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-4080-super",
     "name": "RTX 4080 super"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -49,14 +60,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 2,
-    "listing_count": 2,
+    "listing_count": 3,
     "lowest_new": 1522.0,
     "lowest_refurbished": null,
     "lowest_used": null,
     "retailer_count": 1
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-5090/us.json
+++ b/registry/price/rtx-5090/us.json
@@ -17,17 +17,39 @@
       "retailer": "microcenter",
       "title": "Gigabyte NVIDIA GeForce RTX 5090 Gaming OC Triple Fan 32GB GDDR7 PCIe 5.0 Graphics Card",
       "url": "https://www.microcenter.com/product/690449/gigabyte-nvidia-geforce-rtx-5090-gaming-oc-triple-fan-32gb-gddr7-pcie-50-graphics-card?storeid=151"
+    },
+    {
+      "amount": 2499.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": true,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "microcenter",
+      "title": "PNY NVIDIA GeForce RTX 5090 Overclocked Triple Fan 32GB GDDR7 PCIe 5.0 Graphics Card",
+      "url": "https://www.microcenter.com/product/690483/pny-nvidia-geforce-rtx-5090-overclocked-triple-fan-32gb-gddr7-pcie-50-graphics-card"
+    },
+    {
+      "amount": 5299.99,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "GIGABYTE Gaming GeForce RTX 5090 Graphics Card GV-N5090GAMING OC-32GD",
+      "url": "https://www.newegg.com/gigabyte-gv-n5090gaming-oc-32gd-geforce-rtx-5090-32gb-graphics-card-triple-fans/p/N82E16814932761"
     }
   ],
-  "observed_at": "2026-08-31T12:09:51Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-5090",
     "name": "RTX 5090"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -37,15 +59,15 @@
   },
   "schema_version": "local-ai-registry/v1",
   "summary": {
-    "in_stock_count": 1,
-    "listing_count": 1,
-    "lowest_new": 4499.99,
+    "in_stock_count": 2,
+    "listing_count": 3,
+    "lowest_new": 2499.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }

--- a/registry/price/rtx-6000-ada/us.json
+++ b/registry/price/rtx-6000-ada/us.json
@@ -17,17 +17,28 @@
       "retailer": "bhphotovideo",
       "title": "PNY NVIDIA RTX 6000 Ada Generation Graphics Card",
       "url": "https://www.bhphotovideo.com/c/product/1753962-REG/pny_vcnrtx6000ada_pb_rtx_6000_ada_generation.html"
+    },
+    {
+      "amount": 8900.0,
+      "condition": "new",
+      "currency": "USD",
+      "in_stock": null,
+      "observed_at": "2026-08-31T21:07:10Z",
+      "quantity": null,
+      "retailer": "newegg",
+      "title": "PNY RTX 6000 Ada VCNRTX6000ADA-PB 48GB 384-bit GDDR6 PCI Express 4.0 x16 Graphics Card",
+      "url": "https://www.newegg.com/pny-technologies-inc-vcnrtx6000ada-pb-rtx-6000-ada-48gb-graphics-card/p/N82E16814133886"
     }
   ],
-  "observed_at": "2026-08-31T12:09:51Z",
+  "observed_at": "2026-08-31T21:07:10Z",
   "product": {
     "category": "gpu",
     "id": "rtx-6000-ada",
     "name": "RTX 6000 ada"
   },
   "provenance": {
-    "scanner": "https://github.com/openai/codex",
-    "snapshot_generated_at": "2026-08-31T16:20:00Z",
+    "scanner": "https://claude.ai/code/routines",
+    "snapshot_generated_at": "2026-08-31T21:07:10Z",
     "source_error_count": 32
   },
   "region": {
@@ -38,14 +49,14 @@
   "schema_version": "local-ai-registry/v1",
   "summary": {
     "in_stock_count": 1,
-    "listing_count": 1,
+    "listing_count": 2,
     "lowest_new": 7269.99,
     "lowest_refurbished": null,
     "lowest_used": null,
-    "retailer_count": 1
+    "retailer_count": 2
   },
   "verification": {
-    "method": "codex-cli (gpt-5.6-terra) live web search with per-region subagents; gated by validate_research.py: structure, native currency, https product URL, ISO timestamps, and plausibility vs prior lowest-new (0.35x-3x); URLs verified reachable; pre-existing scanner observations retained and merged",
+    "method": "scheduled claude cloud routine: live web search, native currency, direct retailer URLs, 0.35x-3x plausibility vs prior lowest-new, merged with prior observations",
     "rejected_observations": 0,
     "state": "candidate"
   }


### PR DESCRIPTION
## Summary

Only `registry/` data changed — no code, scripts, schemas, workflows, Makefile, or docs were touched.

**This run hit two environment blockers worth flagging up front:**

1. **Downloads (Hugging Face) — fully blocked.** This session's network egress policy denies `huggingface.co` (403 on every CONNECT, confirmed via the proxy status endpoint). `scripts/fetch_hf_downloads.py` ran against all 660 repos referenced by the 689 model records; every fetch failed. Per the script's own no-regression rule, every prior `last_30d`/`all_time` count was **kept as-is** — nothing was nulled out. 84 records that already had null counts got their `captured_at` timestamp bumped to reflect the (failed) attempt; no actual counts changed.
2. **Price research — WebFetch also blocked.** The same egress policy blocks arbitrary retailer domains too, so the usual "WebFetch the product page to confirm price/stock" step could not run against any of the preferred retailers (microcenter/bhphotovideo/newegg/bestbuy for US; alternate/mindfactory/notebooksbilliger for DE; GB/JP/PL not attempted this run). I fell back to the native web-search tool alone, accepting an observation only when a specific price was explicitly stated in a search result and tied to a real product URL on an approved retailer domain — never estimated, never a search-snippet guess. That tool also has a session-wide call budget which was exhausted partway through the GPU sweep, so coverage is partial. One agent mislabeled RTX 4080 Super listings as plain RTX 4080; caught and dropped during merge.

## Prices — per-region observation counts

| Region | Records touched | Observations added | Duplicates/implausible dropped |
|---|---|---|---|
| US | 12 (GPU) | 18 | 2 |
| DE | 2 (GPU) | 2 | 0 |
| GB | 0 | 0 | — (not reached before search budget ran out) |
| JP | 0 | 0 | — (not reached before search budget ran out) |
| PL | 0 | 0 | — (not reached before search budget ran out) |

All 20 accepted observations are new-condition, real retailer listings with direct HTTPS product URLs, native currency (USD/EUR as listed), passed the 0.35x–3x plausibility check against each record's prior `lowest_new`, and are merged (not replacing) with prior observations. `verification.state` is `candidate` on every touched record; `provenance.scanner` is `https://claude.ai/code/routines`.

Records touched: `dgx-spark`, `intel-arc-pro-b60`, `intel-arc-pro-b70` (US+DE), `radeon-ai-pro-r9700`, `rtx-2000-ada` (US+DE), `rtx-3070-ti`, `rtx-4060-ti`, `rtx-4060`, `rtx-4070-ti-super`, `rtx-4080-super`, `rtx-5090`, `rtx-6000-ada`.

GB/JP/PL and the remaining ~30 US/DE GPU records, plus all non-GPU categories (Apple, AMD mini PC), were not reached this run — recommend a follow-up run, ideally from an environment where the preferred retailer domains and huggingface.co are reachable, or with a larger web-search budget.

## Pipeline

- `python3 scripts/fetch_hf_downloads.py` — ran, all fetches failed (see above)
- `python3 scripts/format_registry.py` — clean
- `python3 scripts/curate_registry.py --index-only` — clean
- `make check` — all green (format-check, validate, 40/40 tests, typecheck, types-check, index-check)

Not merging — CI and repo owner review as usual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfbVpvGzVJaGMNRfqeHNKU)_