### PR TITLE
Cartridge recipes: self-contained, replayable launch commands

### DIFF
--- a/app/api/v1/[...path]/route.ts
+++ b/app/api/v1/[...path]/route.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs"
+import nodePath from "node:path"
+
 import { NextRequest, NextResponse } from "next/server"
 
 import {
@@ -77,9 +80,35 @@ function listResponse(
   })
 }
 
+
+function assetBlob(id: string): NextResponse {
+  if (!/^[a-z0-9][a-z0-9.-]*$/.test(id)) {
+    return response({ error: { code: "not_found", message: "asset not found" } }, 404)
+  }
+  const base = nodePath.join(process.cwd(), "registry", "asset")
+  let manifest: { file: string; media_type?: string; sha256?: string }
+  try {
+    manifest = JSON.parse(readFileSync(nodePath.join(base, `${id}.json`), "utf8"))
+  } catch {
+    return response({ error: { code: "not_found", message: "asset not found" } }, 404)
+  }
+  const blobPath = nodePath.join(base, nodePath.basename(manifest.file))
+  const body = readFileSync(blobPath)
+  return new NextResponse(new Uint8Array(body), {
+    headers: {
+      "content-type": manifest.media_type ?? "application/octet-stream",
+      "x-content-sha256": manifest.sha256 ?? "",
+      "cache-control": "public, max-age=3600",
+    },
+  })
+}
+
 export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
   const { path } = await context.params
   const [resource, id, extra] = path
+  if (resource === "asset" && id && extra === "file") {
+    return assetBlob(id)
+  }
   if (!resource || extra) {
     return response({ error: { code: "not_found", message: "API route not found" } }, 404)
   }

--- a/app/components/launch-command.tsx
+++ b/app/components/launch-command.tsx
@@ -11,8 +11,8 @@ export function LaunchCommand({ recipe }: { recipe: Recipe }) {
       <p className="eyebrow">Launch</p>
       <p className="trust-note">
         Exact materialization of this validated launch contract: digest-pinned image, pinned model revision, and the
-        audited arguments. Registry asset mounts are relative to a checkout of this repository. Also available as
-        <code> local-ai run {recipe.id}</code>.
+        audited arguments. Self-contained — required assets are fetched from this registry and verified against their
+        recorded sha256 before mounting. Also available as <code>local-ai run {recipe.id}</code>.
       </p>
       <pre className="launch-command"><code>{command}</code></pre>
       <CopyActions items={[{ label: "Copy docker command", value: command }]} />

--- a/bin/local-ai
+++ b/bin/local-ai
@@ -239,7 +239,31 @@ launch_args() {
   while IFS=$'\t' read -r source target ro; do
     [[ -n $source ]] || continue
     source=${source/#\~/$HOME}
-    if [[ $source == asset/* ]]; then source="$ROOT/$source"; fi
+    if [[ $source == asset/* ]]; then
+      if [[ -f $ROOT/$source ]]; then
+        source="$ROOT/$source"
+      else
+        # cartridge mode: no checkout — fetch the asset and verify its recorded digest
+        local asset_file asset_id manifest sha cache
+        asset_file=${source#asset/}
+        cache="${TMPDIR:-/tmp}/local-ai-assets"
+        mkdir -p "$cache"
+        asset_id=""
+        while IFS= read -r candidate; do
+          manifest=$(curl -fsSL "${LOCAL_AI_BASE_URL:-https://local-ai-registry.vercel.app}/api/v1/asset/$candidate" 2>/dev/null | jq -c '.data // .' 2>/dev/null) || continue
+          if [[ $(jq -r '.file // empty' <<<"$manifest") == "$asset_file" ]]; then asset_id=$candidate; break; fi
+        done < <(jq -r '.launch.asset_ids[]?' <<<"$recipe")
+        [[ -n $asset_id ]] || fail "asset $asset_file is not declared by this recipe"
+        sha=$(jq -r '.sha256' <<<"$manifest")
+        curl -fsSL "${LOCAL_AI_BASE_URL:-https://local-ai-registry.vercel.app}/api/v1/asset/$asset_id/file" -o "$cache/$asset_file" || fail "could not fetch asset $asset_file"
+        if ! printf '%s  %s\n' "$sha" "$cache/$asset_file" | shasum -a 256 -c - >/dev/null 2>&1; then
+          if ! printf '%s  %s\n' "$sha" "$cache/$asset_file" | sha256sum -c - >/dev/null 2>&1; then
+            fail "asset $asset_file failed sha256 verification"
+          fi
+        fi
+        source="$cache/$asset_file"
+      fi
+    fi
     suffix=""
     if [[ $ro == true ]]; then suffix=":ro"; fi
     LAUNCH+=(-v "${source}:${target}${suffix}")

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -331,10 +331,23 @@ export function hardwareComparison(): HardwareComparisonRow[] {
   })
 }
 
+const REGISTRY_BASE_URL = "https://local-ai-registry.vercel.app"
+
+type AssetManifest = { id: string; file: string; sha256: string }
+
+function assetManifests(recipe: Recipe): AssetManifest[] {
+  const ids = ((recipe.launch as Record<string, unknown>).asset_ids as string[]) ?? []
+  return ids.map((id) => readJson<AssetManifest>("asset", `${id}.json`))
+}
+
 export function dockerCommand(recipe: Recipe): string | null {
   const launch = recipe.launch as Record<string, unknown>
   if (recipe.status !== "validated" || launch.kind !== "docker") return null
   const quote = (part: string) => (/[\s"'$;|&<>()]/.test(part) ? `'${part.replaceAll("'", `'\\''`)}'` : part)
+  const manifests = assetManifests(recipe)
+  const byFile = new Map(manifests.map((manifest) => [manifest.file, manifest]))
+
+  const preamble: string[] = []
   const lines: string[][] = [["docker", "run", "--rm"]]
   if (launch.accelerator_backend === "nvidia") lines.push(["--gpus", "all"])
   if (typeof launch.ipc === "string") lines.push(["--ipc", launch.ipc])
@@ -347,13 +360,31 @@ export function dockerCommand(recipe: Recipe): string | null {
     lines.push(["-e", `${key}=${value}`])
   }
   for (const mount of (launch.mounts as Array<{ source: string; target: string; read_only?: boolean }>) ?? []) {
-    const source = mount.source.startsWith("asset/") ? `./registry/${mount.source}` : mount.source
+    let source = mount.source
+    if (source.startsWith("asset/")) {
+      const file = source.slice("asset/".length)
+      const manifest = byFile.get(file)
+      if (!manifest) return null
+      if (preamble.length === 0) {
+        preamble.push(`ASSETS="\${TMPDIR:-/tmp}/local-ai-assets" && mkdir -p "$ASSETS"`)
+      }
+      preamble.push(
+        `curl -fsSL '${REGISTRY_BASE_URL}/api/v1/asset/${manifest.id}/file' -o "$ASSETS/${file}"`,
+        `{ printf '%s  %s\\n' '${manifest.sha256}' "$ASSETS/${file}" | sha256sum -c - 2>/dev/null || printf '%s  %s\\n' '${manifest.sha256}' "$ASSETS/${file}" | shasum -a 256 -c -; }`,
+      )
+      source = `"$ASSETS/${file}"`
+      lines.push(["-v", `${source}:${mount.target}${mount.read_only ? ":ro" : ""}`])
+      continue
+    }
     lines.push(["-v", `${source}:${mount.target}${mount.read_only ? ":ro" : ""}`])
   }
   if (typeof launch.entrypoint === "string" && launch.entrypoint) lines.push(["--entrypoint", launch.entrypoint])
   lines.push([launch.image as string])
   for (const argument of (launch.arguments as string[]) ?? []) lines.push([argument])
-  return lines.map((line) => line.map(quote).join(" ")).join(" \\\n  ")
+  const docker = lines
+    .map((line) => line.map((part) => (part.startsWith('"$ASSETS/') ? part.replace(/^("\$ASSETS\/[^:]+")/, "$1") : quote(part))).join(" "))
+    .join(" \\\n  ")
+  return preamble.length > 0 ? `${preamble.join(" && \\\n")} && \\\n${docker}` : docker
 }
 
 export function getBenchmark(id: string): Benchmark | undefined {


### PR DESCRIPTION
A recipe is a cartridge: validated means replayable on any machine with Docker and a GPU, from nothing but the recipe. Previously the materialized command assumed a repo checkout for asset mounts. Now:

- The API serves asset blobs at `/api/v1/asset/<id>/file` (content-type from the manifest, `x-content-sha256` header, verified end to end).
- The launch command is fully self-contained: it fetches each required asset from the registry, verifies the manifest's sha256 (portable `sha256sum`/`shasum` alternation), and mounts from a temp dir — the audited in-container hash checks then verify a second time before the patch is applied.
- `local-ai run`/`command` use the local checkout when present and fall back to fetch-and-verify otherwise (`LOCAL_AI_BASE_URL` overridable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
