### PR TITLE
Cartridge completeness: context stated on all validated recipes

### DIFF
--- a/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp1.json
+++ b/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp1.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 131072,
     "tensor_parallel": 1
   },
   "speed_sweep_ids": [

--- a/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp2.json
+++ b/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp2.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 131072,
     "tensor_parallel": 2
   },
   "speed_sweep_ids": [

--- a/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp4.json
+++ b/registry/recipe/qwen36-gptq-int4-rtx3090-vllm-tp4.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 131072,
     "tensor_parallel": 4
   },
   "speed_sweep_ids": [

--- a/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp1.json
+++ b/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp1.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 40960,
     "tensor_parallel": 1
   },
   "speed_sweep_ids": [

--- a/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp2.json
+++ b/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp2.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 131072,
     "tensor_parallel": 2
   },
   "speed_sweep_ids": [

--- a/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp4.json
+++ b/registry/recipe/qwen38-awq-int4-rtx3090-vllm-tp4.json
@@ -139,7 +139,7 @@
   "serving": {
     "kv_cache_tokens": null,
     "max_concurrency": 4,
-    "max_context_tokens": null,
+    "max_context_tokens": 131072,
     "tensor_parallel": 4
   },
   "speed_sweep_ids": [

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -339,6 +339,8 @@ def validate(root):
                         errors.append(f"{recipe['id']}: validated docker launch missing {port_field}")
                 if not launch.get("accelerator_backend"):
                     errors.append(f"{recipe['id']}: validated docker launch missing accelerator_backend")
+                if (recipe.get("serving") or {}).get("max_context_tokens") is None:
+                    errors.append(f"{recipe['id']}: validated recipe must state serving.max_context_tokens")
                 for mount in launch.get("mounts", []):
                     if not isinstance(mount, dict) or not mount.get("source") or not mount.get("target"):
                         errors.append(f"{recipe['id']}: validated docker launch has a malformed mount")


### PR DESCRIPTION
Closes the last gaps in the validated tier: 6 recipes had `--max-model-len` in their audited argv but not in `serving.max_context_tokens` — extracted mechanically, and the validator now requires the field on every validated recipe. Also live-verified the whole tier against Hugging Face: **all 15 distinct pinned (repo, revision) pairs exist, public and ungated**; all 34 recipes have full commit-hash revisions, weight sizes for the disk preflight, and sha256-manifested assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)