### PR TITLE
Promotion pipeline: draft launches + on-hardware acceptance harness

### DIFF
--- a/bin/local-ai
+++ b/bin/local-ai
@@ -344,6 +344,52 @@ launch_args() {
   done < <(jq -j '(.arguments // [])[] | . + "\u0000"' <<<"$launch")
 }
 
+
+cmd_validate() {
+  # Run a candidate's draft (or docker candidate launch) on THIS machine,
+  # accept it with a real completion + speed measurement, and promote it.
+  local force=0
+  if [[ ${1:-} == --force ]]; then force=1; shift; fi
+  [[ ${LOCAL_AI_FORCE:-0} == 1 ]] && force=1
+  local id=$1 recipe contract cname port
+  recipe=$(record recipe "$id")
+  [[ $(jq -r '.status' <<<"$recipe") == candidate ]] || fail "only candidates can be validated; this recipe is $(jq -r '.status' <<<"$recipe")"
+  if [[ $(jq -r '.launch.kind' <<<"$recipe") == docker ]]; then
+    contract=$(jq -c '.launch' <<<"$recipe")
+  else
+    contract=$(jq -c '.draft_launch // empty' <<<"$recipe")
+    [[ -n $contract ]] || fail "this candidate has no docker launch and no draft_launch; run scripts/synthesize_launches.py or curate one"
+  fi
+  # stage the contract first so preflight sees the draft backend and ports
+  local staged
+  staged=$(jq -c --argjson launch "$contract" '.launch = $launch | .status = "validated"' <<<"$recipe")
+  preflight "$staged" "$force"
+  launch_args "$staged"
+  port=$(jq -r '.host_port' <<<"$contract")
+  cname="local-ai-accept-$$"
+  printf 'launching draft for acceptance (container %s, port %s)...\n' "$cname" "$port" >&2
+  # detach: replace 'docker run --rm' with named detached run
+  local detached=("${LAUNCH[@]:0:2}" -d --name "$cname" "${LAUNCH[@]:2}")
+  "${detached[@]}" >/dev/null || fail "docker launch failed"
+  trap 'docker rm -f "'"$cname"'" >/dev/null 2>&1 || true' EXIT
+  printf 'waiting for the server (weights may download; up to 60 minutes)...\n' >&2
+  local waited=0
+  until curl -fsS -m 5 "http://localhost:${port}/v1/models" >/dev/null 2>&1; do
+    if ! docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null | grep -q true; then
+      docker logs --tail 40 "$cname" >&2 || true
+      fail "the server exited before becoming healthy (last logs above)"
+    fi
+    sleep 10; waited=$((waited+10))
+    (( waited % 120 == 0 )) && printf '  still waiting (%ss)...\n' "$waited" >&2
+    (( waited >= 3600 )) && { docker logs --tail 40 "$cname" >&2 || true; fail "server did not become healthy within 60 minutes"; }
+  done
+  printf 'server healthy after %ss; running acceptance...\n' "$waited" >&2
+  python3 "$ROOT/../scripts/accept_recipe.py" "$id" --endpoint "http://localhost:${port}" || fail "acceptance failed; recipe stays candidate"
+  docker rm -f "$cname" >/dev/null 2>&1 || true
+  trap - EXIT
+  printf 'done. Rebuild the index, run make check, and open a PR with the promotion.\n' >&2
+}
+
 cmd_command() {
   local recipe
   recipe=$(record recipe "$1")
@@ -377,6 +423,7 @@ Usage: local-ai [command]
   search <text>                  search all registry records
   command <recipe-id>            print the exact docker command for a validated recipe
   run [--force] <recipe-id>      preflight this machine, then launch a validated recipe
+  validate [--force] <recipe-id> run a candidate draft here, accept it, and promote to validated
 EOF
 }
 
@@ -386,6 +433,7 @@ need jq
 case ${1:-choose} in
   command) shift; [[ $# -eq 1 ]] || fail "usage: local-ai command <recipe-id>"; cmd_command "$1" ;;
   run) shift; [[ $# -ge 1 && $# -le 2 ]] || fail "usage: local-ai run [--force] <recipe-id>"; cmd_run "$@" ;;
+  validate) shift; [[ $# -ge 1 && $# -le 2 ]] || fail "usage: local-ai validate [--force] <recipe-id>"; cmd_validate "$@" ;;
   detect) detect ;;
   list) shift; list "$@" ;;
   choose) choose "${2:-}" ;;

--- a/registry/recipe/agents-a1-4b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/agents-a1-4b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "InternScience/Agents-A1-4B-Q4_K_M-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/btl-4-q4-k-l-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/btl-4-q4-k-l-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/badtheorylabs_BTL-4-GGUF:Q4_K_L",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "180000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/carnice-9b-awq-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/carnice-9b-awq-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "TurbulenceDeterministe/Carnice-9b-W8A16-AWQ",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/carnice-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/carnice-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "kai-os/Carnice-9b-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-r1-distill-qwen-14b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-2jgt4q0j.json
+++ b/registry/recipe/deepseek-r1-distill-qwen-14b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-2jgt4q0j.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-r1-distill-qwen-32b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-4gnp4094.json
+++ b/registry/recipe/deepseek-r1-distill-qwen-32b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-4gnp4094.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-e4m3-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-e4m3-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-e4m3-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-e4m3-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-0731-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-0731-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-0731-iq1-s-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-iq1-s-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/DeepSeek-V4-Flash-0731-GGUF:IQ1_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-0731-iq2-xss-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-iq2-xss-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "AtomicChat/DeepSeek-V4-Flash-0731-GGUF:IQ2_XSS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-0731-mxfp4-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-mxfp4-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Rabbit-Hole-Ai/DeepSeek-V4-Flash-0731-MXFP4-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "196608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-0731-mxfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/deepseek-v4-flash-0731-mxfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-0731-q8-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-q8-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/DeepSeek-V4-Flash-0731-GGUF:Q8_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-0731-ud-iq1-s-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-0731-ud-iq1-s-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/DeepSeek-V4-Flash-0731-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-2-bit-experts-vllm-moet-w2-fp8-kv-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-2-bit-experts-vllm-moet-w2-fp8-kv-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-dspark-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-dspark-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash-DSpark",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-dgx-spark-gb10-128gb-vllm-tp1-nzqc7c66.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-dgx-spark-gb10-128gb-vllm-tp1-nzqc7c66.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "0xSero/DeepSeek-V4-Flash-180B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "200000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "200000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-fltwwrpa.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-fltwwrpa.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-Abliterated-DSpark",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-m27bgdlk.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-m27bgdlk.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-Abliterated",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-t2k45zli.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2-t2k45zli.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-DSpark",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-tuis95dv.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-tuis95dv.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-DSpark",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-uecr5bb0.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-uecr5bb0.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-Abliterated",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/deepseek-v4-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/DeepSeek-V4-Flash-Abliterated-DSpark",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/deepseek-v4-flash-iq2-xxs-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/deepseek-v4-flash-iq2-xxs-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "antirez/deepseek-v4-gguf:IQ2_XXS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "26652"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/deepseek-v4-flash-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/deepseek-v4-flash-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepseek-ai/DeepSeek-V4-Flash",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "500000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/diffusiongemma-26b-a4b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/diffusiongemma-26b-a4b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/diffusiongemma-26B-A4B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/diffusiongemma-26b-a4b-it-fp8-dynamic-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/diffusiongemma-26b-a4b-it-fp8-dynamic-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1-kg2k8vas.json
+++ b/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1-kg2k8vas.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-12B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-12B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/gemma-4-12b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-12B-it",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-coder-fable5-composer2-5-v1-gguf-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-12b-coder-fable5-composer2-5-v1-gguf-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/gemma-4-12B-coder-fable5-composer2.5-MTP-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-7di2u5ts.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-7di2u5ts.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-ty69rqty.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-ty69rqty.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ggml-org/gemma-4-12B-it-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-4070-12gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-4070-12gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "yuxinlu1/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ggml-org/gemma-4-12B-it-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-q4-k-xl-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-q4-k-xl-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12b-it-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-0-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-0-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "google/gemma-4-12B-it-qat-q4_0-gguf",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-0-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-0-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "google/gemma-4-12B-it-qat-q4_0-gguf",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12B-it-qat-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-qat-q4-0-unquantized-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12B-it-qat-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-ud-q5-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-ud-q5-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12b-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-12b-it-ud-q6-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-12b-it-ud-q6-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-12b-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-int8-per-channel-weight-only-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-int8-per-channel-weight-only-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-26B-A4B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-int8-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-int8-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-26B-A4B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-int8-w8a16-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/gemma-4-26b-a4b-int8-w8a16-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-26B-A4B-it",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-it-int4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-int4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-it-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Gemma-4-26B-A4B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-it-nvfp4-modelopt-fp4-w4a4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-nvfp4-modelopt-fp4-w4a4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Gemma-4-26B-A4B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-it-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Gemma-4-26B-A4B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-26b-a4b-it-q3-k-m-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-q3-k-m-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-GGUF:Q3_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-q3-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-q3-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-GGUF:Q3_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-q3-k-xl-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-q3-k-xl-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-GGUF:Q3_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-qat-q4-0-unquantized-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-qat-q4-0-unquantized-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-qat-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-qat-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-it-ud-q8-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-it-ud-q8-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-26B-A4B-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-26b-a4b-q4-k-xl-rtx-4070-12gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-26b-a4b-q4-k-xl-rtx-4070-12gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-26B-A4B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1-24kbd1sh.json
+++ b/registry/recipe/gemma-4-31b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1-24kbd1sh.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-31B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-31b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-31B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-31b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-31B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/gemma-4-31b-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-31B-it",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-int8-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/gemma-4-31b-int8-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "google/gemma-4-31B-it",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gemma-4-31b-it-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-31b-it-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-31B-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-31b-it-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-31b-it-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiconStudio/Gemma-4-31B-it-abliterated-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "70080"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-31b-it-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-31b-it-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-31B-it-GGUF:Q6_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-31b-it-qat-q4-0-unquantized-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-31b-it-qat-q4-0-unquantized-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-31B-it-qat-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "200000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-e2b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-e2b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-e4b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-e4b-it-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gemma-4-E4B-it-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-e4b-it-q8-0-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-e4b-it-q8-0-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bekoozkan/godot-gemma-4-e4b-it-GGUF:Q8_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-e4b-it-qat-q4-0-unquantized-q4-0-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-e4b-it-qat-q4-0-unquantized-q4-0-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "google/gemma-4-E4B-it-qat-q4_0-gguf:Q4_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemma-4-e4b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemma-4-e4b-it-qat-q4-0-unquantized-q4-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "google/gemma-4-E4B-it-qat-q4_0-gguf:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gemmable-4-12b-mtp-gguf-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/gemmable-4-12b-mtp-gguf-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Mia-AiLab/Gemmable-4-12B-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/glm-4-5-air-awq-4bit-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/glm-4-5-air-awq-4bit-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "zai-org/GLM-4.5-Air",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-4-7-flash-int4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/glm-4-7-flash-int4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "QuantTrio/GLM-4.7-Flash-AWQ",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-4-7-flash-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/glm-4-7-flash-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/GLM-4.7-Flash-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/glm-5-1-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-sglang-tp8.json
+++ b/registry/recipe/glm-5-1-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-sglang-tp8.json
@@ -6,6 +6,42 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "lukealonso/GLM-5.1-NVFP4-MTP",
+      "--tp",
+      "8",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/glm-5-2-int4-int8mix-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/glm-5-2-int4-int8mix-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "QuantTrio/GLM-5.2-Int4-Int8Mix",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "200000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-2-mxfp8-nvfp4-nf3-hybrid-mxfp8-nvfp4-nf3-hybrid-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/glm-5-2-mxfp8-nvfp4-nf3-hybrid-mxfp8-nvfp4-nf3-hybrid-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "jacklarmer/GLM-5.2-Abliterated-MXFP8-NVFP4-NF3-Hybrid",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-2-mxfp8-nvfp4-nf3-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/glm-5-2-mxfp8-nvfp4-nf3-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-2-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/glm-5-2-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "0xSero/GLM-5.2-504B-Nvidia",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-2-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/glm-5-2-nvfp4-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "madeby561/GLM-5.2-NVFP4-REAP-504B-term",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-2-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/glm-5-2-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "480000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-3-flash-awq-4bit-rtx-3090-24gb-vllm-tp8.json
+++ b/registry/recipe/glm-5-3-flash-awq-4bit-rtx-3090-24gb-vllm-tp8.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "wtdcode/GLM-5.3-Flash-AWQ-W4A16",
+      "--tensor-parallel-size",
+      "8",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "204800"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-3-flash-exl3-3-0bpw-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/glm-5-3-flash-exl3-3-0bpw-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "zai-org/GLM-5.3-Flash",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "8192"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-3-flash-exl3-4bit-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/glm-5-3-flash-exl3-4bit-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "zai-org/GLM-5.3-Flash",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "352512"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm-5-3-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-7mfqe264.json
+++ b/registry/recipe/glm-5-3-flash-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4-7mfqe264.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "zai-org/GLM-5.3-Flash",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/glm53-flash-exl3-q4-rtxpro6000-sglang-tp2.json
+++ b/registry/recipe/glm53-flash-exl3-q4-rtxpro6000-sglang-tp2.json
@@ -6,6 +6,42 @@
     "vision": null
   },
   "description": "Two-GPU compatibility record for the selective EXL3 Q4 artifact. This is deliberately non-launchable: the published checkpoint is sealed for four tensor-parallel slices, the tested loader requires TP4, and a paired-slice TP2 projection exceeds the per-GPU prepared-weight budget before KV allocation. It exists to prevent a four-GPU command from being misrepresented as a working two-GPU recipe.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "0xSero/GLM-5.3-Flash-EXL3-Q4",
+      "--tp",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/glm53-flash-exl3-q4-rtxpro6000-sglang-tp3.json
+++ b/registry/recipe/glm53-flash-exl3-q4-rtxpro6000-sglang-tp3.json
@@ -6,6 +6,42 @@
     "vision": null
   },
   "description": "Three-GPU compatibility record for the selective EXL3 Q4 artifact. This is deliberately non-launchable: the published checkpoint is sealed as four independently rotated tensor-parallel slices and the loader requires TP4. Mapping four slices to three 96 GB GPUs would place two prepared slices, projected at 106.36 GB before KV cache and workspace, on one GPU.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "0xSero/GLM-5.3-Flash-EXL3-Q4",
+      "--tp",
+      "3",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/godoter-27b-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/godoter-27b-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Ruler97/Godoter-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gpt-oss-120b-mxfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/gpt-oss-120b-mxfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "openai/gpt-oss-120b",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gpt-oss-20b-mxfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/gpt-oss-20b-mxfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "openai/gpt-oss-20b",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/gpt-oss-20b-mxfp4-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/gpt-oss-20b-mxfp4-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ggml-org/gpt-oss-20b-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/gpt-oss-20b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-7ibt565n.json
+++ b/registry/recipe/gpt-oss-20b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-7ibt565n.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/granite-4-2-8b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/granite-4-2-8b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ibm-granite/granite-4.2-8b-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/granite-4-2-8b-q4-k-s-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/granite-4-2-8b-q4-k-s-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ibm-granite/granite-4.2-8b-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/granite-4-2-8b-q5-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/granite-4-2-8b-q5-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ibm-granite/granite-4.2-8b-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/grug-12b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/grug-12b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "kai-os/Grug-12B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/harmonic-hermes-9b-gguf-q6-k-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/harmonic-hermes-9b-gguf-q6-k-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "DJLougen/Harmonic-Hermes-9B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/huihui-qwen3-6-27b-abliterated-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/huihui-qwen3-6-27b-abliterated-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/huihui-qwen3-6-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/huihui-qwen3-6-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/huihui-qwen3-8-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/huihui-qwen3-8-27b-abliterated-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Huihui-Qwen3.8-27B-abliterated-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/huihui-qwythos-9b-claude-mythos-5-1m-abliterated-iq4-xs-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/huihui-qwythos-9b-claude-mythos-5-1m-abliterated-iq4-xs-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "mradermacher/Huihui-Qwythos-9B-Claude-Mythos-5-1M-abliterated-i1-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/hy-mt2-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-va7pd4gi.json
+++ b/registry/recipe/hy-mt2-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-va7pd4gi.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "tencent/Hy-MT2-7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/hy-mt2-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/hy-mt2-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Hy-MT2-7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/hy3-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/hy3-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Jiunsong/SuperHY3-abliterated-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "4096"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/kat-coder-v2-5-dev-q4-k-l-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/kat-coder-v2-5-dev-q4-k-l-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF:Q4_K_L",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/kat-coder-v2-5-dev-q4-k-m-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/kat-coder-v2-5-dev-q4-k-m-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/kat-coder-v2-5-dev-w4a16-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/kat-coder-v2-5-dev-w4a16-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Ar4ikov/KAT-Coder-V2.5-Dev-AWQ-W4A16-ASYM",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/kimi-k2-5-int4-rtx-pro-6000-blackwell-96gb-sglang-tp8.json
+++ b/registry/recipe/kimi-k2-5-int4-rtx-pro-6000-blackwell-96gb-sglang-tp8.json
@@ -6,6 +6,42 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "moonshotai/Kimi-K2.5",
+      "--tp",
+      "8",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "SGLang",

--- a/registry/recipe/laguna-s-2-1-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4-4bolsk2a.json
+++ b/registry/recipe/laguna-s-2-1-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4-4bolsk2a.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/laguna-s-2-1-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-DFlash",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/laguna-s-2-1-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-DFlash-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/laguna-s-2-1-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-DFlash-FP8",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/laguna-s-2-1-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-nvfp4-rtx-5090-32gb-vllm-tp4.json
+++ b/registry/recipe/laguna-s-2-1-nvfp4-rtx-5090-32gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-NVFP4",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/laguna-s-2-1-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-S-2.1-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-s-2-1-q4-k-m-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/laguna-s-2-1-q4-k-m-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "poolside/Laguna-S-2.1-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "9280"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/laguna-xs-2-1-int4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/laguna-xs-2-1-int4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-XS-2.1-INT4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-xs-2-1-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/laguna-xs-2-1-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "poolside/Laguna-XS-2.1-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/laguna-xs-2-1-q3-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/laguna-xs-2-1-q3-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "poolside/Laguna-XS-2.1-GGUF:Q3_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/laguna-xs-2-1-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/laguna-xs-2-1-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "poolside/Laguna-XS-2.1-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/laguna-xs-2-1-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/laguna-xs-2-1-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "poolside/Laguna-XS-2.1-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/lfm2-5-1-2b-instruct-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/lfm2-5-1-2b-instruct-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/lfm2-5-1-2b-instruct-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/lfm2-5-1-2b-instruct-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/lfm2-5-8b-a1b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/lfm2-5-8b-a1b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/lfm2-5-8b-a1b-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/lfm2-5-8b-a1b-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "128000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/lfm2-5-8b-a1b-q6-k-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/lfm2-5-8b-a1b-q6-k-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "LiquidAI/LFM2.5-8B-A1B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "128000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ling-2-6-flash-compressed-tensors-int4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/ling-2-6-flash-compressed-tensors-int4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "inclusionAI/Ling-2.6-flash",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "32768"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/ling-2-6-flash-modelopt-fp4-experts-only-b16-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/ling-2-6-flash-modelopt-fp4-experts-only-b16-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "inclusionAI/Ling-2.6-flash",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "32768"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/ling-2-6-flash-modelopt-fp4-mlp-only-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/ling-2-6-flash-modelopt-fp4-mlp-only-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "inclusionAI/Ling-2.6-flash",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "65536"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/ling-2-6-flash-modelopt-fp4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/ling-2-6-flash-modelopt-fp4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "inclusionAI/Ling-2.6-flash",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "32768"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/llama-3-1-8b-instruct-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/llama-3-1-8b-instruct-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Llama-3.1-8B-Instruct-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/mellum2-12b-a2-5b-instruct-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/mellum2-12b-a2-5b-instruct-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "JetBrains/Mellum2-12B-A2.5B-Instruct-GGUF-Q4_K_M:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/mellum2-12b-a2-5b-thinking-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/mellum2-12b-a2-5b-thinking-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "JetBrains/Mellum2-12B-A2.5B-Thinking-GGUF-Q4_K_M:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/mimo-v2-5-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/mimo-v2-5-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "lukealonso/MiMo-V2.5-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "500000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/mimo-v2-5-q4-k-m-gguf-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/mimo-v2-5-q4-k-m-gguf-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/MiMo-V2.5-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1000000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/minimax-m2-7-awq-4bit-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/minimax-m2-7-awq-4bit-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/MiniMax-M2.7-AWQ-4bit",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "190000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/muse-glimmer-30b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "meta-models/Muse-Glimmer-30B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/muse-glimmer-30b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/Muse-Glimmer-30B-FP8-block",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/muse-glimmer-30b-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Preyazz/Muse-Glimmer-30B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "4096"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/muse-glimmer-30b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Preyazz/Muse-Glimmer-30B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/muse-glimmer-30b-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "meta-models/Muse-Glimmer-30B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/muse-glimmer-30b-q4-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-q4-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "meta-models/Muse-Glimmer-30B-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/muse-glimmer-30b-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Muse-Glimmer-30B-GGUF:Q8_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/muse-glimmer-30b-ud-q3-k-xl-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/muse-glimmer-30b-ud-q3-k-xl-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Muse-Glimmer-30B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nemotron-3-nano-omni-30b-a3b-reasoning-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/nemotron-3-nano-omni-30b-a3b-reasoning-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "10000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nemotron-cascade-2-30b-a3b-iq4-xs-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/nemotron-cascade-2-30b-a3b-iq4-xs-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "bartowski/nvidia_Nemotron-Cascade-2-30B-A3B-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-bf16-nvfp4-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-bf16-nvfp4-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ggml-org/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-gguf-iq4-xs-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-gguf-iq4-xs-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-gguf-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-gguf-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-nvfp4-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-lightning-30b-a3b-nvfp4-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-3-5-nvfp4-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-nvfp4-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-3-5-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-3-5-q4-k-m-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-5-q4-k-m-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "lmstudio-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-3-nano-30b-a3b-bf16-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-nano-30b-a3b-bf16-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-3-nano-4b-bf16-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-nano-4b-bf16-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/NVIDIA-Nemotron-3-Nano-4B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-nano-4b-fp8-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-nano-4b-fp8-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/nvidia-nemotron-3-super-120b-a12b-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/nvidia-nemotron-3-super-120b-a12b-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4-q4-k-s-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4-q4-k-s-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "HackerTwins/NVIDIA-Nemotron-Labs-3-Elastic-23B-A2.8B-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/openreasoning-nemotron-32b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/openreasoning-nemotron-32b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/OpenReasoning-Nemotron-32B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/openreasoning-nemotron-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/openreasoning-nemotron-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/OpenReasoning-Nemotron-7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/openreasoning-nemotron-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/openreasoning-nemotron-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/OpenReasoning-Nemotron-7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-0-35b-aeon-ultimate-uncensored-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-aeon-ultimate-uncensored-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Ornith-1.0-35B-AEON-Ultimate-Uncensored-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-awq-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-awq-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Ornith-1.0-35B-AWQ-INT4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-gguf-nvfp4-qwen35moe-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-gguf-nvfp4-qwen35moe-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Frosty40/Ornith-1.0-35B-GGUF-NVFP4",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.0-35B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-4070-12gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-4070-12gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "ornith-ai/Ornith-1.0-35B-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-gguf-q4-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.0-35B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "524288"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-0-35b-mixed4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-mixed4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "rdtand/Ornith-1.0-35B-PrismaAURA-4.75bit-vllm-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "rdtand/Ornith-1.0-35B-PrismaAURA-4.75bit-vllm-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-nvfp4-rtx-5090-32gb-vllm-tp2.json
+++ b/registry/recipe/ornith-1-0-35b-nvfp4-rtx-5090-32gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "palmfuture/Ornith-1.0-35B-NVFP4A16",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-35b-q4-k-m-rtx-4070-12gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-35b-q4-k-m-rtx-4070-12gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "deepreinforce-ai/Ornith-1.0-35B-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-397b-w4a16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-0-397b-w4a16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "fraserprice/Ornith-1.0-397B-W4A16-AutoRound-DFlash",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-397b-w4a16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/ornith-1-0-397b-w4a16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Pilcothink/Ornith-1.0-397B-W4A16-AutoRound",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-0-9b-gguf-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-0-9b-gguf-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.0-9B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-gguf-apex-mtp-i-compact-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-gguf-apex-mtp-i-compact-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-gguf-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-gguf-q4-k-m-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-gguf-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-gguf-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-gguf-q6-k-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-gguf-q6-k-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-mtp-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-mtp-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "mradermacher/Ornith-1.5-35B-A3B-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-35b-a3b-nvfp4-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/ornith-1-5-35b-a3b-nvfp4-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "ornith-ai/Ornith-1.5-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/ornith-1-5-9b-gguf-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-9b-gguf-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-9B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-9b-gguf-q5-k-m-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-9b-gguf-q5-k-m-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-9B-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornith-1-5-9b-gguf-q6-k-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornith-1-5-9b-gguf-q6-k-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "ornith-ai/Ornith-1.5-9B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/ornstein3-6-27b-mtp-nsc-ace-saber-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/ornstein3-6-27b-mtp-nsc-ace-saber-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/phi-4-mini-reasoning-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/phi-4-mini-reasoning-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Phi-4-mini-reasoning-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/phi-4-mini-reasoning-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/phi-4-mini-reasoning-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Phi-4-mini-reasoning-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen2-5-coder-14b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen2-5-coder-14b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen2.5-Coder-14B-Instruct",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-0-6b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-0-6b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Qwen/Qwen3-0.6B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-1-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-1-7b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-1-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-1-7b-q4-k-m-rtx-3060-ti-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Qwen/Qwen3-1.7B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-14b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-14b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3-14B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-14b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-14b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3-14B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-14b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-14b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3-14B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-0-8b-base-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-0-8b-base-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-0.8B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-0-8b-bf16-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-0-8b-bf16-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-0.8B-GGUF:BF16",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-0-8b-q8-0-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-0-8b-q8-0-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwen3.5-0.8B-Claude-4.6-Opus-Reasoning-Distilled-GGUF:Q8_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-122b-a10b-awq-rtx-3090-24gb-vllm-tp4.json
+++ b/registry/recipe/qwen3-5-122b-a10b-awq-rtx-3090-24gb-vllm-tp4.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-122b-a10b-awq-w4a16-sym-64x1024-grid8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-122b-a10b-awq-w4a16-sym-64x1024-grid8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "0xSero/Qwen3.5-122B-A10B-REAP-20",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-122b-a10b-fp8-rtx-3090-24gb-vllm-tp8.json
+++ b/registry/recipe/qwen3-5-122b-a10b-fp8-rtx-3090-24gb-vllm-tp8.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-122B-A10B-FP8",
+      "--tensor-parallel-size",
+      "8",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-122b-a10b-gptq-int4-rtx-3090-24gb-vllm-tp8.json
+++ b/registry/recipe/qwen3-5-122b-a10b-gptq-int4-rtx-3090-24gb-vllm-tp8.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-122B-A10B-GPTQ-Int4",
+      "--tensor-parallel-size",
+      "8",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-122b-a10b-int4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-122b-a10b-int4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Intel/Qwen3.5-122B-A10B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-27b-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-5-27b-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Intel/Qwen3.5-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "4096"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-27b-q4-0-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-27b-q4-0-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-27B-GGUF:Q4_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-27b-q4-0-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-27b-q4-0-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-27B-GGUF:Q4_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-zxl9rg5u.json
+++ b/registry/recipe/qwen3-5-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-zxl9rg5u.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwopus3.5-27B-v3-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-27b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-27b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-27b-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-27b-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-35b-a3b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-35b-a3b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-35B-A3B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-35b-a3b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-35b-a3b-ud-q8-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-35b-a3b-ud-q8-k-xl-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-4b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-4b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-awq-int4-rtx-3060-12gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-5-9b-awq-int4-rtx-3060-12gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Qwen3.5-9B-AWQ-4bit",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-9b-base-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-9b-base-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.5-9B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-5-9b-q4-1-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-9b-q4-1-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-9B-GGUF:Q4_1",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-bah9z5zv.json
+++ b/registry/recipe/qwen3-5-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-bah9z5zv.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-9B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-9b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-q4-k-s-rtx-5070-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-9b-q4-k-s-rtx-5070-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.5-9B-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-q8-0-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-5-9b-q8-0-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/DeepSeek-V4-Pro-Qwen3.5-9B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-5-9b-q8-0-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-5-9b-q8-0-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Jackrong/DeepSeek-V4-Pro-Qwen3.5-9B-MTP-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-modelopt-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-modelopt-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-mtp-xs-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-mtp-xs-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-bf16-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "256000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-aeon-ultimate-uncensored-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-auto-rtx-5090-32gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-auto-rtx-5090-32gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-autoround-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-autoround-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-autoround-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-autoround-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-int4-rtx-3060-12gb-vllm-tp2-68h7yf95.json
+++ b/registry/recipe/qwen3-6-27b-awq-int4-rtx-3060-12gb-vllm-tp2-68h7yf95.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "QuantTrio/Qwen3.6-27B-AWQ",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "4104"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-int4-rtx-3060-12gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-awq-int4-rtx-3060-12gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "drawais/Qwen3.6-27B-AWQ-INT4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-int4-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-awq-int4-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-awq-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-rtx-3090-24gb-vllm-tp4.json
+++ b/registry/recipe/qwen3-6-27b-awq-rtx-3090-24gb-vllm-tp4.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-awq-rtx-5060-ti-16gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-awq-rtx-5060-ti-16gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Qwen3.6-27B-AWQ-INT4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:BF16",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/qwen3-6-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp16-rtx-4090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp16-rtx-4090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-dgx-spark-gb10-128gb-sglang-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp8-dgx-spark-gb10-128gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "65536"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-6-27b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-e4m3-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp8-e4m3-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-3090-ti-24gb-vllm-tp2-f8a8wm4k.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-3090-ti-24gb-vllm-tp2-f8a8wm4k.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-3090-ti-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-3090-ti-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-5090-32gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-5090-32gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-autoround-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-int4-autoround-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-int4-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-rtx-5060-ti-16gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-int4-rtx-5060-ti-16gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-rtx-5060-ti-16gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-int4-rtx-5060-ti-16gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Lorbus/Qwen3.6-27B-int4-AutoRound",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-int4-rtx-a6000-48gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-int4-rtx-a6000-48gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-iq1-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-iq1-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "mradermacher/Qwen3.6-27B-i1-GGUF:IQ1_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-iq1-s-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-iq1-s-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "mradermacher/Qwen3.6-27B-i1-GGUF:IQ1_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-iq4-xs-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-iq4-xs-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-3sj0zzr0.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-3sj0zzr0.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-62k8tt93.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-62k8tt93.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-sg1v1o0x.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-sg1v1o0x.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-v5lfqrqu.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-v5lfqrqu.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-modelopt-mixed-w4a16-fp8-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-modelopt-mixed-w4a16-fp8-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5060-ti-16gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5060-ti-16gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-mly0g8a6.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-mly0g8a6.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-pb3yoj0c.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-pb3yoj0c.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-puvumomq.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-puvumomq.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-sghfjxa7.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1-sghfjxa7.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-5090-32gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-an6x9onb.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-an6x9onb.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-syk1ywe8.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-syk1ywe8.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-zo7jgcek.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-zo7jgcek.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "kaitchup/Qwen3.6-27B-autoround-nvfp4-linearattn-BF16",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/qwen3-6-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-27B-NVFP4",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-q1-0-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q1-0-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "prism-ml/Bonsai-27B-gguf",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q1-0-rtx-3090-24gb-llama-cpp-tp1-jg8rvua0.json
+++ b/registry/recipe/qwen3-6-27b-q1-0-rtx-3090-24gb-llama-cpp-tp1-jg8rvua0.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:Q1_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q1-0-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q1-0-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "prism-ml/Bonsai-27B-gguf",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q3-k-m-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q3-k-m-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:Q3_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-y82lvs6e.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1-y82lvs6e.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "lmstudio-community/Qwen3.6-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-ti-24gb-llama-cpp-tp1-jm347jzo.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-3090-ti-24gb-llama-cpp-tp1-jm347jzo.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "73728"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "76000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-m-rtx-5090-32gb-llama-cpp-tp1-vaasia9h.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-m-rtx-5090-32gb-llama-cpp-tp1-vaasia9h.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF:Q4_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "114688"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1-k1vkl3qa.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1-k1vkl3qa.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "AtomicChat/Qwen3.6-27B-UDT-MTP-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-q6-k-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-q6-k-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-MTP-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-iq2-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-iq2-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-iq2-xxs-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-iq2-xxs-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q3-k-xl-rtx-5090-32gb-llama-cpp-tp1-iwhamj9o.json
+++ b/registry/recipe/qwen3-6-27b-ud-q3-k-xl-rtx-5090-32gb-llama-cpp-tp1-iwhamj9o.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1-z6k4gjcp.json
+++ b/registry/recipe/qwen3-6-27b-ud-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1-z6k4gjcp.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q5-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-q5-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-ud-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-ud-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved-q4-k-m-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-27b-uncensored-heretic-v2-native-mtp-preserved-q4-k-m-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-awq-dgx-spark-gb10-128gb-vllm-tp1-yv0te57k.json
+++ b/registry/recipe/qwen3-6-35b-a3b-awq-dgx-spark-gb10-128gb-vllm-tp1-yv0te57k.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-awq-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-awq-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "QuantTrio/Qwen3.6-35B-A3B-AWQ",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-bf16-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-bf16-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "32768"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-6-35b-a3b-compressed-tensors-nvfp4-fp8-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-compressed-tensors-nvfp4-fp8-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-fp8-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-35b-a3b-fp8-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B-FP8",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "4096"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-gptq-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-gptq-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-gptq4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-gptq4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-heretic-nvfp4-compressed-tensors-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-heretic-nvfp4-compressed-tensors-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-heretic-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-heretic-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "229376"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-35b-a3b-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-iq3-xxs-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-iq3-xxs-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:IQ3_XXS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "150000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-iq4-nl-rtx-5060-ti-16gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-iq4-nl-rtx-5060-ti-16gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:IQ4_NL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-7ye39t14.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-7ye39t14.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-35B-A3B-NVFP4-Fast",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-fehrcah8.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-fehrcah8.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-m6i8dge6.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1-m6i8dge6.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1-d83arulq.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1-d83arulq.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1-mj82rijd.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1-mj82rijd.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Infatoshi/Qwen3.6-35B-A3B-NVFP4-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-5090-32gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-gunngyna.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1-gunngyna.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "mmangkad/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "8192"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
+++ b/registry/recipe/qwen3-6-35b-a3b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp4.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "--tensor-parallel-size",
+      "4",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-q2-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q2-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q2_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-n9hocnod.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1-n9hocnod.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1-etimxv7c.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1-etimxv7c.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "64000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "64000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-m-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-s-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-s-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q4-k-xl-rtx-4060-8gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q4-k-xl-rtx-4060-8gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "128000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-iq2-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-iq2-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-iq4-nl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-iq4-nl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-iq4-xs-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-iq4-xs-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8320"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-q3-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-q3-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "163840"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-m-rtx-4070-12gb-vllm-tp1-xmn9blhn.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-m-rtx-4070-12gb-vllm-tp1-xmn9blhn.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-m-rtx-4070-12gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-m-rtx-4070-12gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.6-35B-A3B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-xl-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-q4-k-xl-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "150000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-ud-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-ud-q5-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-unsloth-dynamic-iq4-xs-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-unsloth-dynamic-iq4-xs-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-a3b-unsloth-dynamic-q4-k-m-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-6-35b-a3b-unsloth-dynamic-q4-k-m-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-6-35b-reap-pruned-ratio-0-5-nvfp4-rtx-5070-ti-16gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-6-35b-reap-pruned-ratio-0-5-nvfp4-rtx-5070-ti-16gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sroecker/Qwen3.6-35B-REAP-Pruned-ratio-0.5-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-ad-iq2-xs-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ad-iq2-xs-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "AtomicChat/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-bf16-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-bf16-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:BF16",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "99100"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-bf16-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-cold-fusion-gain-v1-1-xs-pro-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-cold-fusion-gain-v1-1-xs-pro-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "zerodigest/Qwen3.8-27B-Cold-Fusion-GAIN-V1.1-YMQ-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "20480"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-fp8-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-fp8-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-fp8-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-gptq-4bit-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-8-27b-gptq-4bit-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "btbtyler09/Qwen3.8-27B-GPTQ-4bit",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "8192"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-int4-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-8-27b-int4-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-iq2-xxs-rtx-3080-10gb-llama-cpp-tp1-hfssqgv8.json
+++ b/registry/recipe/qwen3-8-27b-iq2-xxs-rtx-3080-10gb-llama-cpp-tp1-hfssqgv8.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:IQ2_XXS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-iq2-xxs-rtx-3080-10gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-iq2-xxs-rtx-3080-10gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "orcarouter/Qwen3.8-27B-Uncensored-GGUF:IQ2_XXS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-iq4-nl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-iq4-nl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:IQ4_NL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-iq4-xs-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-iq4-xs-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-iq4-xs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-iq4-xs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:IQ4_XS",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-2vr2r04n.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-2vr2r04n.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4-BF16-LMHead",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-76nhlseh.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-76nhlseh.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "unsloth/Qwen3.8-27B-NVFP4",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-ahj9l2q3.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-ahj9l2q3.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "unsloth/Qwen3.8-27B-NVFP4",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-jg9ym3sv.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-jg9ym3sv.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-qh8u9odj.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-qh8u9odj.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-thetonv3.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-sglang-tp1-thetonv3.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4-BF16-LMHead",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "131072"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RadixArk/Qwen3.8-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-5060-ti-16gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-5060-ti-16gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-sglang-tp2.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-sglang-tp2.json
@@ -6,6 +6,42 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4-BF16-LMHead",
+      "--tp",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1-3w070u2g.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1-3w070u2g.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "unsloth/Qwen3.8-27B-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1-9ypy422c.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1-9ypy422c.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.8-27B-MTP-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "172800"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-pro-6000-blackwell-96gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "RadixArk/Qwen3.8-27B-NVFP4-BF16-LMHead",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "262144"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "sakamakismile/Qwen3.8-27B-MTP-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-q3-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q3-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q3_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q3-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q3-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q3_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-0-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-0-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "262144"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-0-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-0-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-1-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-1-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_1",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-k-s-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-k-s-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q4-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q4-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q4_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q5-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q5-k-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q5_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q5-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q5-k-s-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q5_K_S",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1-d7trg181.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1-d7trg181.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Rabbit-Hole-Ai/Qwen3.8-27B-5090-goldilocks-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1-l7yvwzwd.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1-l7yvwzwd.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "AtomicChat/Qwen3.8-27B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q6_K",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-xl-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q6_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q6_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131000"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q8-0-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q8-0-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q8_0",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF:Q8_K_XL",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "99100"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ridge-3-7bpw-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ridge-3-7bpw-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "empero-ai/Qwen3.8-27B-Ridge-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "16384"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq2-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq2-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq2-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq2-m-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq2-xxs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq3-xxs-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq3-xxs-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-iq3-xxs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-iq3-xxs-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-5070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q2-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q3-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q3-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q3-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q3-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-4090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "172032"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q4-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q5-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q5-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "65536"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q5-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q5-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q6-k-xl-rtx-5090-32gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "8192"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q6-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q6-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-ud-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-27b-ud-q8-k-xl-rtx-pro-6000-blackwell-96gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "unsloth/Qwen3.8-27B-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-27b-w4a16-autoround-rtx-3090-24gb-sglang-tp2-y0tyt5cf.json
+++ b/registry/recipe/qwen3-8-27b-w4a16-autoround-rtx-3090-24gb-sglang-tp2-y0tyt5cf.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing result. It is evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "dbirks/Qwen3.8-27B-W4A16-AutoRound",
+      "--tp",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "2048"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/qwen3-8-27b-w4a16-autoround-rtx-3090-24gb-vllm-tp2.json
+++ b/registry/recipe/qwen3-8-27b-w4a16-autoround-rtx-3090-24gb-vllm-tp2.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "dbirks/Qwen3.8-27B-W4A16-AutoRound",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-w4a16-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-w4a16-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3.8-27B",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "65536"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-w4a16-rtx-5090-32gb-vllm-tp1-go03hdzd.json
+++ b/registry/recipe/qwen3-8-27b-w4a16-rtx-5090-32gb-vllm-tp1-go03hdzd.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "philbert440/Qwen3.8-27B-W4A16-AWQ",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "2048"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-27b-w4a16-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-27b-w4a16-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "pearsonkyle/Qwen3.8-27B-GPTQ-W4A16",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-8-9b-distill-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwen3-8-9b-distill-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "empero-ai/Qwen3.8-9B-Distill-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "131072"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwen3-8-flash-next-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-8-flash-next-nvfp4-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "RadixArk/Qwen3.8-Flash-Next-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "262144"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-coder-30b-a3b-instruct-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-coder-30b-a3b-instruct-fp8-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-coder-30b-a3b-instruct-int4-rtx-5090-32gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-coder-30b-a3b-instruct-int4-rtx-5090-32gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "AIDXteam/Qwen3-Coder-30B-A3B-Instruct-AWQ",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "Qwen/Qwen3-Coder-Next-FP8",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwen3-next-80b-a3b-instruct-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
+++ b/registry/recipe/qwen3-next-80b-a3b-instruct-nvfp4-dgx-spark-gb10-128gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "32768"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwopus3-5-9b-v3-5-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwopus3-5-9b-v3-5-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4608"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwopus3-6-27b-v2-gptq-rtx-3090-24gb-vllm-tp1.json
+++ b/registry/recipe/qwopus3-6-27b-v2-gptq-rtx-3090-24gb-vllm-tp1.json
@@ -6,6 +6,41 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "XReyRobert/Qwopus3.6-27B-v2-GPTQ-Pro-v1",
+      "--tensor-parallel-size",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000",
+      "--max-model-len",
+      "131072"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/qwopus3-6-35b-a3b-v1-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwopus3-6-35b-a3b-v1-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "Jackrong/Qwopus3.6-35B-A3B-Coder-MTP-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwythos-9b-claude-mythos-5-1m-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwythos-9b-claude-mythos-5-1m-q4-k-m-rtx-4070-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "4096"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwythos-9b-v2-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwythos-9b-v2-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "empero-ai/Qwythos-9B-v2-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "32768"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/qwythos-9b-v2-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
+++ b/registry/recipe/qwythos-9b-v2-q4-k-m-rtx-3090-24gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "empero-ai/Qwythos-9B-v2-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "1024"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/step-3-7-flash-ud-iq4-nl-gguf-dgx-spark-gb10-128gb-llama-cpp-tp1.json
+++ b/registry/recipe/step-3-7-flash-ud-iq4-nl-gguf-dgx-spark-gb10-128gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "stepfun-ai/Step-3.7-Flash-GGUF",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "2048"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/thinkingcap-qwen3-6-27b-w4a16-int4-autoround-rtx-3060-12gb-vllm-tp2.json
+++ b/registry/recipe/thinkingcap-qwen3-6-27b-w4a16-int4-autoround-rtx-3060-12gb-vllm-tp2.json
@@ -6,6 +6,39 @@
     "vision": null
   },
   "description": null,
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "--model",
+      "josefprusa/ThinkingCap-Qwen3.6-27B-int4-AutoRound-v1",
+      "--tensor-parallel-size",
+      "2",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8000"
+    ],
+    "container_port": 8000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 8000,
+    "image": "vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1",
+      "template": "vllm-openai-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "vllm",

--- a/registry/recipe/unlimited-ocr-fp16-rtx-3090-24gb-sglang-tp1.json
+++ b/registry/recipe/unlimited-ocr-fp16-rtx-3090-24gb-sglang-tp1.json
@@ -6,6 +6,44 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "baidu/Unlimited-OCR",
+      "--tp",
+      "1",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--context-length",
+      "2048"
+    ],
+    "container_port": 30000,
+    "entrypoint": null,
+    "environment": {},
+    "host_port": 30000,
+    "image": "lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1",
+      "template": "sglang-launch-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "sglang",

--- a/registry/recipe/webworld-14b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/webworld-14b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "DhruvalLabs/WebWorld-14B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/recipe/webworld-8b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
+++ b/registry/recipe/webworld-8b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1.json
@@ -6,6 +6,43 @@
     "vision": null
   },
   "description": "Observed LocalMaxxing leaderboard run. Evidence for compatibility, not an executable launch contract.",
+  "draft_launch": {
+    "accelerator_backend": "nvidia",
+    "arguments": [
+      "-hf",
+      "DhruvalLabs/WebWorld-8B-GGUF:Q4_K_M",
+      "--n-gpu-layers",
+      "999",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8080",
+      "-c",
+      "512"
+    ],
+    "container_port": 8080,
+    "entrypoint": null,
+    "environment": {
+      "LLAMA_CACHE": "/root/.cache/huggingface"
+    },
+    "host_port": 8080,
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2",
+    "ipc": "host",
+    "kind": "docker",
+    "mounts": [
+      {
+        "read_only": false,
+        "source": "~/.cache/huggingface",
+        "target": "/root/.cache/huggingface"
+      }
+    ],
+    "shm_size": "16g",
+    "synthesized": {
+      "generated_at": "2026-08-31T22:12:17Z",
+      "image_provenance": "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1",
+      "template": "llama-cpp-server-v1"
+    }
+  },
   "engine": {
     "graph_mode": null,
     "name": "llama.cpp",

--- a/registry/schema/recipe.schema.json
+++ b/registry/schema/recipe.schema.json
@@ -155,6 +155,106 @@
         "type": "string"
       },
       "uniqueItems": true
+    },
+    "draft_launch": {
+      "type": "object",
+      "description": "Synthesized, UNVERIFIED docker launch draft used only by the acceptance harness (local-ai validate). Never a launch contract: the observed launch stays authoritative until acceptance promotes the recipe, at which point draft_launch becomes launch and is removed.",
+      "required": [
+        "kind",
+        "image",
+        "arguments",
+        "host_port",
+        "container_port",
+        "accelerator_backend",
+        "synthesized"
+      ],
+      "properties": {
+        "kind": {
+          "const": "docker"
+        },
+        "image": {
+          "type": "string",
+          "pattern": "@sha256:[0-9a-f]{64}$"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "entrypoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "mounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "read_only": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "host_port": {
+          "type": "integer"
+        },
+        "container_port": {
+          "type": "integer"
+        },
+        "ipc": {
+          "type": "string"
+        },
+        "shm_size": {
+          "type": "string"
+        },
+        "accelerator_backend": {
+          "type": "string"
+        },
+        "synthesized": {
+          "type": "object",
+          "required": [
+            "template",
+            "generated_at",
+            "image_provenance"
+          ],
+          "properties": {
+            "template": {
+              "type": "string"
+            },
+            "generated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "image_provenance": {
+              "type": "string",
+              "description": "Which audited registry recipe this image digest was taken from."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
   "allOf": [

--- a/registry/schema/types.ts
+++ b/registry/schema/types.ts
@@ -65,6 +65,36 @@ export type Recipe = {
   provenance: Provenance
   facts: Facts
   speed_sweep_ids: string[]
+  /**
+   * Synthesized, UNVERIFIED docker launch draft used only by the acceptance harness (local-ai validate). Never a launch contract: the observed launch stays authoritative until acceptance promotes the recipe, at which point draft_launch becomes launch and is removed.
+   */
+  draft_launch?: {
+    kind: "docker"
+    image: string
+    arguments: string[]
+    entrypoint?: string | null
+    environment?: {
+      [k: string]: string
+    }
+    mounts?: {
+      source: string
+      target: string
+      read_only?: boolean
+    }[]
+    host_port: number
+    container_port: number
+    ipc?: string
+    shm_size?: string
+    accelerator_backend: string
+    synthesized: {
+      template: string
+      generated_at: string
+      /**
+       * Which audited registry recipe this image digest was taken from.
+       */
+      image_provenance: string
+    }
+  }
 }
 export type Container = {
   state: "digest-pinned" | "mutable" | "indirect" | "none"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,3 +42,22 @@ speed-sweep evidence.
 - Observed source commands never become launch contracts: candidate imports
   stay `launch.kind: "reference"` and tokenized argv lives in metadata
   (`tokenize_observed_command.py` docstring has the full rules).
+
+## Promotion: candidates to cartridges
+
+Observed candidates keep `launch.kind: reference` forever — the evidence
+is never rewritten. The path to a validated, replayable recipe:
+
+1. `synthesize_launches.py` adds a `draft_launch` to eligible candidates
+   (NVIDIA vllm/sglang/llama.cpp today) — a mechanically generated,
+   UNVERIFIED docker contract built from the candidate's own facts and an
+   image digest already audited elsewhere in this registry.
+2. On the target hardware: `local-ai validate <recipe-id>` preflights the
+   machine, launches the draft, waits for health, runs a real completion
+   with streaming TTFT/decode measurement (`accept_recipe.py`), pins the
+   served model revision, writes an acceptance speed-sweep, and promotes:
+   draft_launch becomes launch, status becomes validated.
+3. Rebuild the index, run `make check`, commit, open a PR. CI re-verifies
+   everything the promotion claims.
+
+A failed acceptance changes nothing: the recipe stays a candidate.

--- a/scripts/accept_recipe.py
+++ b/scripts/accept_recipe.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Acceptance + promotion for a launched draft recipe.
+
+Run by `local-ai validate` AFTER the draft server is up. Performs a real
+completion, measures streaming TTFT and decode rate, pins the model
+revision that was actually served, writes a speed-sweep evidence record,
+and promotes the recipe: draft_launch becomes launch, status becomes
+validated. Refuses to promote when any pillar of the trust contract
+cannot be satisfied.
+"""
+
+import argparse
+import datetime as dt
+import json
+import re
+import ssl
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "registry"
+CTX = ssl.create_default_context()
+NOW = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def http_json(url, payload=None, timeout=120):
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout, context=CTX) as response:
+        return json.load(response)
+
+
+def measure(endpoint, model, prompt_tokens=256, output_tokens=128, samples=3):
+    prompt = "Summarize the history of computing. " * (prompt_tokens // 8)
+    rows = []
+    for _ in range(samples):
+        started = time.monotonic()
+        first = None
+        completion_tokens = 0
+        request = urllib.request.Request(
+            f"{endpoint}/v1/chat/completions",
+            data=json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}], "max_tokens": output_tokens, "stream": True}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=600, context=CTX) as response:
+            for line in response:
+                if not line.startswith(b"data:"):
+                    continue
+                chunk = line[5:].strip()
+                if chunk == b"[DONE]":
+                    break
+                if first is None:
+                    first = time.monotonic()
+                completion_tokens += 1
+        finished = time.monotonic()
+        if first is None or completion_tokens < 8:
+            raise SystemExit("acceptance FAILED: the server produced no usable completion")
+        decode = (completion_tokens - 1) / max(finished - first, 1e-6)
+        rows.append({"ttft_ms": (first - started) * 1000, "decode_tok_s": decode, "tokens": completion_tokens})
+    return rows
+
+
+def pinned_revision(repo):
+    data = http_json(f"https://huggingface.co/api/models/{repo}")
+    sha = data.get("sha")
+    if not (isinstance(sha, str) and re.fullmatch(r"[0-9a-f]{40}", sha)):
+        raise SystemExit(f"acceptance FAILED: could not pin a revision for {repo}")
+    return sha
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("recipe_id")
+    parser.add_argument("--endpoint", required=True)
+    args = parser.parse_args()
+
+    path = ROOT / "recipe" / f"{args.recipe_id}.json"
+    recipe = json.loads(path.read_text())
+    draft = recipe.get("draft_launch") or (recipe["launch"] if recipe["launch"].get("kind") == "docker" else None)
+    if recipe["status"] != "candidate" or draft is None:
+        raise SystemExit("acceptance only applies to candidates with a docker draft or docker launch")
+
+    served = http_json(f"{args.endpoint}/v1/models")["data"][0]["id"]
+    print(f"server is healthy; serving model id: {served}")
+    runs = measure(args.endpoint, served)
+    decode = sorted(run["decode_tok_s"] for run in runs)[len(runs) // 2]
+    ttft = sorted(run["ttft_ms"] for run in runs)[len(runs) // 2]
+    print(f"acceptance measurements: decode {decode:.1f} tok/s, ttft {ttft:.0f} ms over {len(runs)} samples")
+
+    instance_path = ROOT / "model-instance" / f"{recipe['model_instance_id']}.json"
+    instance = json.loads(instance_path.read_text())
+    if not (isinstance(instance.get("revision"), str) and re.fullmatch(r"[0-9a-f]{40}", instance["revision"] or "")):
+        instance["revision"] = pinned_revision(instance["repository"])
+        instance_path.write_text(json.dumps(instance, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+        print(f"pinned model revision {instance['revision'][:12]}")
+
+    serving = recipe.setdefault("serving", {})
+    if serving.get("max_context_tokens") is None:
+        for flag in ("--max-model-len", "--context-length", "-c"):
+            arguments = draft.get("arguments", [])
+            if flag in arguments:
+                serving["max_context_tokens"] = int(arguments[arguments.index(flag) + 1])
+                break
+    if serving.get("max_context_tokens") is None:
+        raise SystemExit("acceptance FAILED to promote: serving.max_context_tokens unknown and not stated in the draft")
+
+    sweep_id = f"{recipe['id']}-acceptance"
+    row = {
+        "concurrency": 1,
+        "context_tokens": serving.get("max_context_tokens"),
+        "output_tokens": 128,
+        "prefill_tok_s": None,
+        "decode_tok_s": round(decode, 1),
+        "decode_tok_s_per_stream": round(decode, 1),
+        "ttft_ms_p50": round(ttft, 1),
+        "peak_vram_gb": None,
+        "samples": len(runs),
+        "status": "accepted",
+    }
+    sweep = {
+        "schema_version": "local-ai-registry/v1",
+        "id": sweep_id,
+        "recipe_id": recipe["id"],
+        "measured_at": NOW,
+        "accepted_at": NOW,
+        "source": {"kind": "acceptance-run", "url": "https://github.com/0xSero/local-ai-registry", "repository": None, "commit": None, "paths": None},
+        "metrics": {"concurrency": 1, "point_count": len(runs), "max_context_tokens": serving.get("max_context_tokens"), "peak_generation_tps": round(decode, 1), "peak_prompt_tps": None, "latest_point_at": NOW},
+        "rows": [row],
+    }
+    (ROOT / "speed-sweep" / f"{sweep_id}.json").write_text(json.dumps(sweep, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+    launch = {key: value for key, value in draft.items() if key != "synthesized"}
+    digest = "sha256:" + launch["image"].split("@sha256:")[1]
+    launch["container"] = {
+        "state": "digest-pinned",
+        "runtime": "docker",
+        "image": launch["image"],
+        "digest": digest,
+        "compose_file": None,
+        "reason": "image-reference-in-launch",
+        "captured_at": NOW,
+        "source": [{"kind": "acceptance-run", "url": "https://github.com/0xSero/local-ai-registry", "captured_at": NOW}],
+    }
+    recipe["launch"] = launch
+    recipe.pop("draft_launch", None)
+    recipe["status"] = "validated"
+    recipe.setdefault("speed_sweep_ids", [])
+    if sweep_id not in recipe["speed_sweep_ids"]:
+        recipe["speed_sweep_ids"].append(sweep_id)
+    recipe.setdefault("metadata", {})["acceptance"] = {"accepted_at": NOW, "served_model_id": served, "harness": "local-ai validate"}
+    path.write_text(json.dumps(recipe, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+    print(f"PROMOTED {recipe['id']} to validated with evidence {sweep_id}")
+    print("next: python3 scripts/curate_registry.py --index-only && python3 scripts/format_registry.py && make check, then commit and open a PR")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/synthesize_launches.py
+++ b/scripts/synthesize_launches.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Synthesize draft docker launches for observed reference candidates.
+
+The observed recipe stays exactly what it is — evidence with
+launch.kind reference. This adds draft_launch: a mechanically generated,
+UNVERIFIED docker contract built from the candidate's own facts (model
+repository, quantization, tensor parallel, context) and an image digest
+already audited elsewhere in this registry. Drafts exist for one
+purpose: `local-ai validate <id>` runs them on the target hardware and
+promotes the recipe only after a real completion and speed acceptance.
+
+NVIDIA-only for now (vllm, sglang, llama.cpp with GGUF-hosting repos,
+single-GPU llama.cpp only). Run from the repository root; idempotent.
+"""
+
+import datetime as dt
+import json
+import re
+from pathlib import Path
+
+ROOT = Path("registry")
+NOW = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+# Audited digest-pinned images already trusted by this registry, per engine.
+IMAGES = {
+    "vllm": ("vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967", "deepseek-fp8-rtx-pro-6000-blackwell-96gb-vllm-tp1"),
+    "sglang": ("lmsysorg/sglang:dev-cu13@sha256:6cd4635214f279e0a43019f88e3120d407567640a58aa7dcc0085e3d91402cc4", "gemma-4-12b-it-nvfp4-rtxpro6000-sglang-tp1"),
+    "llama.cpp": ("ghcr.io/ggml-org/llama.cpp:server-cuda12-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107f0f0857e259672d1cb85b71c2", "gemma-4-12b-q4-k-m-rtx-3060-12gb-llama-cpp-tp1"),
+}
+CACHE_MOUNT = {"source": "~/.cache/huggingface", "target": "/root/.cache/huggingface", "read_only": False}
+GGUF_QUANT = re.compile(r"^(I?Q[0-9][A-Z0-9_]*|F16|BF16|F32)$", re.IGNORECASE)
+
+
+def base(template, engine_key, host_port, container_port, arguments, environment=None):
+    image, provenance = IMAGES[engine_key]
+    return {
+        "kind": "docker",
+        "image": image,
+        "entrypoint": None,
+        "arguments": arguments,
+        "environment": environment or {},
+        "mounts": [dict(CACHE_MOUNT)],
+        "host_port": host_port,
+        "container_port": container_port,
+        "ipc": "host",
+        "shm_size": "16g",
+        "accelerator_backend": "nvidia",
+        "synthesized": {"template": template, "generated_at": NOW, "image_provenance": provenance},
+    }
+
+
+def synthesize(recipe, instance):
+    engine = recipe["engine"]["name"]
+    repo = instance.get("repository")
+    if not isinstance(repo, str) or "/" not in repo:
+        return None, "no usable repository"
+    serving = recipe.get("serving") or {}
+    tp = serving.get("tensor_parallel") or recipe.get("hardware_count") or 1
+    ctx = serving.get("max_context_tokens")
+
+    if engine == "vllm":
+        arguments = ["--model", repo, "--tensor-parallel-size", str(tp), "--host", "0.0.0.0", "--port", "8000"]
+        if isinstance(ctx, int) and ctx > 0:
+            arguments += ["--max-model-len", str(ctx)]
+        return base("vllm-openai-v1", "vllm", 8000, 8000, arguments), None
+
+    if engine in ("sglang", "SGLang"):
+        arguments = ["python3", "-m", "sglang.launch_server", "--model-path", repo, "--tp", str(tp), "--host", "0.0.0.0", "--port", "30000"]
+        if isinstance(ctx, int) and ctx > 0:
+            arguments += ["--context-length", str(ctx)]
+        draft = base("sglang-launch-server-v1", "sglang", 30000, 30000, arguments)
+        draft["entrypoint"] = None
+        return draft, None
+
+    if engine == "llama.cpp":
+        if tp != 1:
+            return None, "llama.cpp draft limited to single GPU"
+        quant = (instance.get("weights") or {}).get("format") or ""
+        if "gguf" not in repo.lower():
+            return None, "repository does not host GGUF artifacts"
+        spec = f"{repo}:{quant}" if GGUF_QUANT.fullmatch(quant or "") else repo
+        arguments = ["-hf", spec, "--n-gpu-layers", "999", "--host", "0.0.0.0", "--port", "8080"]
+        if isinstance(ctx, int) and ctx > 0:
+            arguments += ["-c", str(ctx)]
+        draft = base("llama-cpp-server-v1", "llama.cpp", 8080, 8080, arguments, {"LLAMA_CACHE": "/root/.cache/huggingface"})
+        return draft, None
+
+    return None, f"no template for engine {engine}"
+
+
+def main():
+    created = skipped = 0
+    reasons = {}
+    for path in sorted((ROOT / "recipe").glob("*.json")):
+        recipe = json.loads(path.read_text())
+        if recipe["status"] != "candidate" or recipe["launch"].get("kind") != "reference":
+            continue
+        hardware = json.loads((ROOT / "hardware" / f"{recipe['hardware_id']}.json").read_text())
+        if hardware["vendor"] != "nvidia":
+            continue
+        instance = json.loads((ROOT / "model-instance" / f"{recipe['model_instance_id']}.json").read_text())
+        draft, reason = synthesize(recipe, instance)
+        if draft is None:
+            skipped += 1
+            reasons[reason] = reasons.get(reason, 0) + 1
+            continue
+        if recipe.get("draft_launch") == draft:
+            continue
+        recipe["draft_launch"] = draft
+        path.write_text(json.dumps(recipe, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+        created += 1
+    print(f"drafts written: {created}; skipped: {skipped}")
+    for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+        print(f"  skip: {reason}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -327,6 +327,12 @@ def validate(root):
             if recipe.get("hardware_id") != "apple-m5-max-128gb":
                 errors.append(f"{recipe['id']}: mlx.fast official scores map only to apple-m5-max-128gb")
         validate_tokenized_launch(recipe, errors)
+        draft = recipe.get("draft_launch")
+        if draft is not None:
+            if status != "candidate":
+                errors.append(f"{recipe['id']}: draft_launch is only allowed on candidates")
+            if not re.search(r"@sha256:[0-9a-f]{64}$", str(draft.get("image", ""))):
+                errors.append(f"{recipe['id']}: draft_launch image must be digest-pinned")
         if recipe.get("recipe_source") == "omlx":
             errors.append(f"{recipe['id']}: speculative oMLX recipes are outside the registry contract")
         if status == "validated":


### PR DESCRIPTION
The road from 34 validated cartridges to thousands — without ever faking a validation.

- **451 candidates now carry `draft_launch`**: mechanically synthesized, schema-enforced, explicitly UNVERIFIED docker contracts (NVIDIA vllm / sglang / single-GPU GGUF llama.cpp), built from each candidate's own facts and image digests already audited in this registry. The observed `reference` launch is never touched — doctrine intact. Every ineligible candidate has a recorded skip reason (non-GGUF repos, multi-GPU llama.cpp, ollama/lmstudio desktop engines, non-NVIDIA vendors — templates to come).
- **`local-ai validate [--force] <id>`** is the acceptance harness: hardware preflight against the staged draft → detached launch → health polling (60-min budget for weight downloads, container-death detection with log tails) → real streamed completions measuring TTFT + decode → pins the served revision → writes an acceptance speed-sweep → promotes draft→launch, candidate→validated. **A failed acceptance changes nothing.**
- CI re-verifies every promotion claim on the resulting PR (digest pin, revision pin, evidence, context, materializability).

To grow the validated tier: run `local-ai validate <id>` on the machines the candidates name — each GPU box can churn its own queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
